### PR TITLE
Fixed some minor warnings + code style suggestion

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,5 +1,4 @@
-const String API_URL =
-    "https://mentorship-backend-temp.herokuapp.com/"; // TODO Find a better way to store it
+const String API_URL = "https://mentorship-backend-temp.herokuapp.com/";
 
 const String STATS_PAGE_TITLE = "Home";
 const String PROFILE_PAGE_TITLE = "My Profile";

--- a/lib/remote/repositories/auth_repository.dart
+++ b/lib/remote/repositories/auth_repository.dart
@@ -24,8 +24,7 @@ class AuthRepository {
   }
 
   Future<void> register(Register register) async {
-    final body =
-        await ApiManager.callSafely(() => ApiManager.instance.authService.register(register));
+    await ApiManager.callSafely(() => ApiManager.instance.authService.register(register));
   }
 
   Future<void> deleteToken() async {

--- a/lib/remote/repositories/relation_repository.dart
+++ b/lib/remote/repositories/relation_repository.dart
@@ -65,6 +65,7 @@ class RelationRepository {
     try {
       return Relation.fromJson(body);
     } on NoSuchMethodError catch (error) {
+      print(error);
       // This means the Response Body is not a Relation. In such case the API returns a message.
       throw Failure(CustomResponse.fromJson(body).message);
     }

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -27,6 +27,7 @@ class _ProfilePageState extends State<ProfilePage> {
 
   @override
   Widget build(BuildContext context) {
+    //ignore: close_sinks
     ProfilePageBloc bloc = BlocProvider.of<ProfilePageBloc>(context)..add(ProfilePageShowed());
 
     _nameController..addListener(() => bloc.user.name = _nameController.text);
@@ -51,6 +52,7 @@ class _ProfilePageState extends State<ProfilePage> {
       return Scaffold(
         floatingActionButton: FloatingActionButton(
           onPressed: () {
+            //ignore: close_sinks
             final bloc = BlocProvider.of<ProfilePageBloc>(context);
 
             if (state is ProfilePageEditing) {

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -86,6 +86,7 @@ class _RelationPageState extends State<RelationPage> {
             color: Theme.of(context).accentColor,
             child: Text("Cancel".toUpperCase(), style: TextStyle(color: Colors.white)),
             onPressed: () {
+              //ignore: close_sinks
               final bloc = BlocProvider.of<RelationPageBloc>(context);
 
               showDialog(
@@ -135,6 +136,7 @@ class _RelationPageState extends State<RelationPage> {
             itemCount: state.tasks.length,
             itemBuilder: (context, index) {
               Task task = state.tasks[index];
+              //ignore: close_sinks
               final bloc = BlocProvider.of<RelationPageBloc>(context);
 
               return InkWell(
@@ -184,6 +186,7 @@ class _RelationPageState extends State<RelationPage> {
   Widget _buildFab(BuildContext context, RelationPageSuccess state) {
     final _taskInputController = TextEditingController();
 
+    //ignore: close_sinks
     final bloc = BlocProvider.of<RelationPageBloc>(context);
 
     return FloatingActionButton(

--- a/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
+++ b/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
@@ -6,7 +6,6 @@ import 'package:logging/logging.dart';
 import 'package:mentorship_client/failure.dart';
 import 'package:mentorship_client/remote/models/relation.dart';
 import 'package:mentorship_client/remote/repositories/relation_repository.dart';
-import 'package:mentorship_client/remote/responses/custom_response.dart';
 
 import './bloc.dart';
 

--- a/lib/screens/home/pages/stats/stats_page.dart
+++ b/lib/screens/home/pages/stats/stats_page.dart
@@ -44,7 +44,7 @@ class _StatsPageState extends State<StatsPage> {
                           alignment: Alignment.centerLeft,
                           child: Text(
                             "Recent Achievements",
-                            style: Theme.of(context).textTheme.title,
+                            style: Theme.of(context).textTheme.headline6,
                           )),
                     ),
                     for (Task achievement in state.homeStats.achievements)
@@ -89,11 +89,11 @@ class _StatsPageState extends State<StatsPage> {
         children: [
           Text(
             text,
-            style: Theme.of(context).textTheme.title.apply(color: Colors.grey[600]),
+            style: Theme.of(context).textTheme.headline6.apply(color: Colors.grey[600]),
           ),
           Text(
             count.toString(),
-            style: Theme.of(context).textTheme.subtitle.copyWith(fontWeight: FontWeight.bold),
+            style: Theme.of(context).textTheme.subtitle2.copyWith(fontWeight: FontWeight.bold),
           ),
         ],
       ),

--- a/lib/screens/login/bloc/login_bloc.dart
+++ b/lib/screens/login/bloc/login_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:bloc/bloc.dart';
-import 'package:logging/logging.dart';
 import 'package:mentorship_client/auth/auth_bloc.dart';
 import 'package:mentorship_client/auth/bloc.dart';
 import 'package:mentorship_client/failure.dart';

--- a/lib/screens/send_request/send_request_screen.dart
+++ b/lib/screens/send_request/send_request_screen.dart
@@ -49,6 +49,7 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
   }
 
   Widget _buildBody(BuildContext context) {
+    //ignore: close_sinks
     SendRequestBloc bloc = BlocProvider.of<SendRequestBloc>(context);
 
     return ListView(

--- a/lib/widgets/bold_text.dart
+++ b/lib/widgets/bold_text.dart
@@ -12,7 +12,7 @@ class BoldText extends StatelessWidget {
     return RichText(
       maxLines: maxLines,
       text: TextSpan(
-        style: Theme.of(context).textTheme.body1,
+        style: Theme.of(context).textTheme.bodyText2,
         children: [
           TextSpan(text: firstText, style: TextStyle(fontWeight: FontWeight.bold)),
           TextSpan(text: secondText)


### PR DESCRIPTION
### Description
I fixed some warnings raised by the linter. Mainly:

- `'subtitle' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle2. This feature was deprecated after v1.13.8..
Try replacing the use of the deprecated member with the replacement.`
Replaced all such usages of 2014-spec with respective 2018 versions.

- `Close instances of 'dart.core.Sink'.`
This is a false positive, as [described here](https://github.com/felangel/bloc/issues/587). I suggest **enforcing people to put linter exception rule before such a safe usage of BLOC.** (below):
```dart
//ignore: close_sinks
SendRequestBloc bloc = BlocProvider.of<SendRequestBloc>(context);
```
This way, we'll have safe, false positives suppressed, but still get lint for any future non-BLOC related usages of Dart Stream API.

- Also, removed all unused imports

### First code style rules
Although [`dartfmt`](https://dart.dev/tools/dartfmt) does a lot of work already, we need even stricter rules to maintain consistent style in the future. 

I suggest:
- **Column line width set to 100**. 80 is simply too small.
This can be easily set in Android Studio/IntelliJ Dart code style settings tab (example below):
<img width="991" alt="Screenshot 2020-04-17 at 12 09 28 AM" src="https://user-images.githubusercontent.com/40357511/79511535-c3883500-803f-11ea-97d4-b9264ed87d74.png">


In VSCode you have open settings and set Dart: Line Length to 100 (example below):
<img width="588" alt="Screenshot 2020-04-17 at 12 06 30 AM" src="https://user-images.githubusercontent.com/40357511/79511396-8459e400-803f-11ea-8fb2-63ee3a83ed1e.png">

- **Enforcing the aforementioned use of //ignore: close_sinks in context of safe usages of BLOCs**

This is just a draft, but if we agree on this, I'll update README with the style guide info.

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
All features work fine on Pixel 3a (API 29) emulator.


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any dependent changes have been published in downstream modules