### PR TITLE
Updated link of Code of Conduct in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing Guidelines
 
 - You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). Each active repo has its own stream to direct questions to (for example #powerup or #portal). Mentorship System stream is [#mentorship-system](https://anitab-org.zulipchat.com/#narrow/stream/222534-mentorship-system).
-- Remember that this is an inclusive community, committed to creating a safe, positive environment. See the full [Code of Conduct](http://www.systers.io/code-of-conduct.html).
+- Remember that this is an inclusive community, committed to creating a safe, positive environment. See the full [Code of Conduct](code_of_conduct.md).
 - Follow our [Commit Message Style Guide](https://github.com/anitab-org/mentorship-android/wiki/Commit-Message-Style-Guide) when you commit your changes.
 - Please consider raising an issue before submitting a pull request (PR) to solve a problem that is not present in our [issue tracker](https://github.com/anitab-org/mentorship-flutter/issues). This allows maintainers to first validate the issue you are trying to solve and also reference the PR to a specific issue.
 - When developing a new feature, include at least one test when applicable.


### PR DESCRIPTION
Replaced the existing link of Code of Conduct to the new link which is code_of_conduct.md

### Description
Replaced the existing link of Code of Conduct to the new link which is code_of_conduct.md

Fixes #44 

### Type of Change:
- Documentation

### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged