### PR TITLE
docs: remove travis "master" build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 | Branch | [Travis](https://travis-ci.org/) 
 | :---: | :---: |
-| [master](https://github.com/anitab-org/mentorship-flutter/tree/master) | [![Build Status](https://travis-ci.com/anitab-org/mentorship-flutter.svg?branch=master)](https://travis-ci.com/anitab-org/mentorship-flutter) 
 | [develop](https://github.com/anitab-org/mentorship-flutter/tree/develop) | [![Build Status](https://travis-ci.com/anitab-org/mentorship-flutter.svg?branch=develop)](https://travis-ci.com/anitab-org/mentorship-flutter) 
 
 Mentorship System is an application that allows women in tech to mentor each other, on career development topics, through 1:1 relations for a certain period of time.


### PR DESCRIPTION
### Description
Removed the travis "master" build status from readme as we will not be using that branch.

Fixes #53 

### Type of Change:

- Documentation





### How Has This Been Tested?
Checked readme


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

- [x] I have made corresponding changes to the documentation



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
