### PR TITLE
feat: add helper text on requests page

### DIFF
--- a/lib/screens/home/pages/requests/requests_page.dart
+++ b/lib/screens/home/pages/requests/requests_page.dart
@@ -40,15 +40,15 @@ class _RequestsPageState extends State<RequestsPage> {
             return TabBarView(
               children: [
                 pendingRelations.length == 0
-                    ? NoRequestHelper(message: "You don't have any pending mentorship requests.")
+                    ? NoRequestsInfo(message: "You don't have any pending mentorship requests.")
                     : _buildRequestsTab(context, pendingRelations),
                 pastRelations.length == 0
-                    ? NoRequestHelper(
+                    ? NoRequestsInfo(
                         message: "You don't have any past mentorship requests.",
                       )
                     : _buildRequestsTab(context, pastRelations),
                 allRelations.length == 0
-                    ? NoRequestHelper(message: "You don't have any mentorship requests.")
+                    ? NoRequestsInfo(message: "You don't have any mentorship requests.")
                     : _buildRequestsTab(context, allRelations),
               ],
             );
@@ -120,9 +120,9 @@ class _RequestsPageState extends State<RequestsPage> {
   }
 }
 
-class NoRequestHelper extends StatelessWidget {
+class NoRequestsInfo extends StatelessWidget {
   final String message;
-  const NoRequestHelper({this.message});
+  const NoRequestsInfo({this.message});
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/lib/screens/home/pages/requests/requests_page.dart
+++ b/lib/screens/home/pages/requests/requests_page.dart
@@ -40,28 +40,15 @@ class _RequestsPageState extends State<RequestsPage> {
             return TabBarView(
               children: [
                 pendingRelations.length == 0
-                    ? Center(
-                        child: Text(
-                          "You don't have any pending mentorship requests.",
-                          style: TextStyle(fontSize: 18, color: Colors.grey),
-                        ),
-                      )
+                    ? NoRequestHelper(message: "You don't have any pending mentorship requests.")
                     : _buildRequestsTab(context, pendingRelations),
                 pastRelations.length == 0
-                    ? Center(
-                        child: Text(
-                          "You don't have any past mentorship requests.",
-                          style: TextStyle(fontSize: 18, color: Colors.grey),
-                        ),
+                    ? NoRequestHelper(
+                        message: "You don't have any past mentorship requests.",
                       )
                     : _buildRequestsTab(context, pastRelations),
                 allRelations.length == 0
-                    ? Center(
-                        child: Text(
-                          "You don't have any mentorship requests.",
-                          style: TextStyle(fontSize: 18, color: Colors.grey),
-                        ),
-                      )
+                    ? NoRequestHelper(message: "You don't have any mentorship requests.")
                     : _buildRequestsTab(context, allRelations),
               ],
             );
@@ -129,6 +116,20 @@ class _RequestsPageState extends State<RequestsPage> {
           ),
         );
       },
+    );
+  }
+}
+
+class NoRequestHelper extends StatelessWidget {
+  final String message;
+  const NoRequestHelper({this.message});
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        message,
+        style: TextStyle(fontSize: 18, color: Colors.grey),
+      ),
     );
   }
 }

--- a/lib/screens/home/pages/requests/requests_page.dart
+++ b/lib/screens/home/pages/requests/requests_page.dart
@@ -39,9 +39,30 @@ class _RequestsPageState extends State<RequestsPage> {
 
             return TabBarView(
               children: [
-                _buildRequestsTab(context, pendingRelations),
-                _buildRequestsTab(context, pastRelations),
-                _buildRequestsTab(context, allRelations),
+                pendingRelations.length == 0
+                    ? Center(
+                        child: Text(
+                          "You don't have any pending mentorship requests.",
+                          style: TextStyle(fontSize: 18, color: Colors.grey),
+                        ),
+                      )
+                    : _buildRequestsTab(context, pendingRelations),
+                pastRelations.length == 0
+                    ? Center(
+                        child: Text(
+                          "You don't have any past mentorship requests.",
+                          style: TextStyle(fontSize: 18, color: Colors.grey),
+                        ),
+                      )
+                    : _buildRequestsTab(context, pastRelations),
+                allRelations.length == 0
+                    ? Center(
+                        child: Text(
+                          "You don't have any mentorship requests.",
+                          style: TextStyle(fontSize: 18, color: Colors.grey),
+                        ),
+                      )
+                    : _buildRequestsTab(context, allRelations),
               ],
             );
           }


### PR DESCRIPTION
### Description
This block of code adds the helper text "you have {x} mentorship requests" to the requests page

Fixes #68 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- User Interface


**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
On my physical device 
![image](https://user-images.githubusercontent.com/52817235/81996926-030c6600-966c-11ea-9b3a-fd8791aecf34.png)
![image](https://user-images.githubusercontent.com/52817235/81996934-07388380-966c-11ea-8235-ef15daa1955c.png)




### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
