### PR TITLE
Added new rule to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,29 @@ Apart from [formatting your code using `dartfmt`](https://flutter.dev/docs/devel
 
   **Visual Studio Code**:
   <img width="964" alt="VSCode format" src="https://user-images.githubusercontent.com/40357511/80772789-21e10780-8b58-11ea-9e22-7ebdf0b61977.png">
+
+- To create reusable pieces of UI, create a new class extending `StatelessWidget`. Do not create functions returning `Widget`.
+  [Why?](https://stackoverflow.com/questions/53234825/what-is-the-difference-between-functions-and-classes-to-create-reusable-widgets)
+
+  Example of **bad code**
+
+  ```
+  Widget _buildSomeWidgets(BuildContext context) {
+    return Center(
+      child: Text("Hi!"),
+    );
+  }
+  ```
+
+  Example of **good code**
+
+  ```
+  class _SomeWidgets extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      return Center(
+        child: Text("Hi!"),
+      );
+    }
+  }
+  ```


### PR DESCRIPTION
### to 
  ```
  Widget _buildSomeWidgets(BuildContext context) {
    return Center(
      child: Text("Hi!"),
    );
  }
  ```

  ### or

  ```
  class _SomeWidgets extends StatelessWidget {
    @override
    Widget build(BuildContext context) {
      return Center(
        child: Text("Hi!"),
      );
    }
  }
  ```

  ## That is the question.
  > Well, no longer. Do use option **2**. Do extend `StatelessWidget` instead of creating `function(BuildContext) -> Widget`

All this PR is about is [in this great StackOverflow thread](https://stackoverflow.com/questions/53234825/what-is-the-difference-between-functions-and-classes-to-create-reusable-widgets). I decided to enforce the recommended solution to our project to sort this out and provide clear guidance on this.

Currently, this project has quite a few *methods returning `Widget`s*, but it'll be quite easy to refactor them to classes that `extend StatelessWidget`.

It's a small change, so I didn't create an issue.

### Type of Change:

- Documentation

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation