### PR TITLE
Prefer Logger.root over print()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,12 @@ Apart from [formatting your code using `dartfmt`](https://flutter.dev/docs/devel
 
   **Visual Studio Code**:
   <img width="964" alt="VSCode format" src="https://user-images.githubusercontent.com/40357511/80772789-21e10780-8b58-11ea-9e22-7ebdf0b61977.png">
+
+- When you want to print something to the console, *do not* use `print()`; use `Logger.root` instead. You should also use appropriate log leve. Example:
+    ```
+    if (token != null) {
+          Logger.root.info("Found a token.");
+        } else {
+          Logger.root.severe("Error: no token!");
+        }
+    ```

--- a/lib/remote/repositories/relation_repository.dart
+++ b/lib/remote/repositories/relation_repository.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:mentorship_client/failure.dart';
 import 'package:mentorship_client/remote/api_manager.dart';
 import 'package:mentorship_client/remote/models/relation.dart';
@@ -65,7 +66,7 @@ class RelationRepository {
     try {
       return Relation.fromJson(body);
     } on NoSuchMethodError catch (error) {
-      print(error);
+      Logger.root.info(error);
       // This means the Response Body is not a Relation. In such case the API returns a message.
       throw Failure(CustomResponse.fromJson(body).message);
     }

--- a/lib/screens/settings/about.dart
+++ b/lib/screens/settings/about.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:expandable/expandable.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AboutPage extends StatelessWidget {
   @override
@@ -28,7 +29,7 @@ _launchURL() async {
   if (await canLaunch(url)) {
     await launch(url);
   } else {
-    print("Could not launch");
+    Logger.root.warning("Error: Could not launch $url");
   }
 }
 


### PR DESCRIPTION
### Description
`print()` is fast, but (very!) dirty. We have to manually include all the information that we want, and if we don't, we might end up with the following output in the console:

```
loading data
debug # 2
loaded data
error
debug # 1
fix this in the future
test5
```

Logger is a class from [Dart's official logging package](https://pub.dev/packages/logging). After some initial configuration, it's easy to *log with style*:

```
I/flutter (17106): INFO: 2020-05-18 12:46:08.911003: AppStarted
I/flutter (17106): INFO: 2020-05-18 12:46:11.354172: Has token!
I/flutter (17106): INFO: 2020-05-18 12:46:11.361696: Transition { currentState: AuthUninitialized, event: AppStarted, nextState: AuthAuthenticated }
I/flutter (17106): INFO: 2020-05-18 12:46:11.686906: StatsPageShowed
I/flutter (17106): INFO: 2020-05-18 12:46:11.780145: Transition { currentState: StatsPageInitial, event: StatsPageShowed, nextState: StatsPageLoading }
I/flutter (17106): INFO: 2020-05-18 12:46:11.842777: --> GET https://mentorship-backend-temp.herokuapp.com/home
I/flutter (17106): INFO: 2020-05-18 12:46:11.848238: --> END GET
I/flutter (17106): INFO: 2020-05-18 12:46:11.859703: Has token!
```

I also refactored all uses of `print()` to `Logger.root`.

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Does not affect business logic.
Everything works fine.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)