### PR TITLE
feat: add loading indicator when changing password and saving profile

### DIFF
--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -56,6 +56,7 @@ class _ProfilePageState extends State<ProfilePage> {
             final bloc = BlocProvider.of<ProfilePageBloc>(context);
 
             if (state is ProfilePageEditing) {
+              showloader(context);
               bloc.add(ProfilePageEditSubmitted(BlocProvider.of<ProfilePageBloc>(context).user));
             } else if (state is ProfilePageSuccess) {
               bloc.add(ProfilePageEditStarted());
@@ -70,6 +71,7 @@ class _ProfilePageState extends State<ProfilePage> {
           listener: (context, state) {
             if (state.message != null) {
               context.showSnackBar(state.message);
+              Navigator.of(context).pop();
             }
           },
           child: BlocBuilder<ProfilePageBloc, ProfilePageState>(builder: (context, state) {
@@ -218,6 +220,13 @@ class _ProfilePageState extends State<ProfilePage> {
         labelText: text,
         border: UnderlineInputBorder(),
       ),
+    );
+  }
+
+  Future<void> showloader(BuildContext context) {
+    return showDialog(
+      context: context,
+      child: LoadingIndicator(),
     );
   }
 }

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -226,6 +226,7 @@ class _ProfilePageState extends State<ProfilePage> {
   Future<void> showloader(BuildContext context) {
     return showDialog(
       context: context,
+      barrierDismissible: false,
       child: LoadingIndicator(),
     );
   }

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -56,7 +56,7 @@ class _ProfilePageState extends State<ProfilePage> {
             final bloc = BlocProvider.of<ProfilePageBloc>(context);
 
             if (state is ProfilePageEditing) {
-              showloader(context);
+              showProgressIndicator(context);
               bloc.add(ProfilePageEditSubmitted(BlocProvider.of<ProfilePageBloc>(context).user));
             } else if (state is ProfilePageSuccess) {
               bloc.add(ProfilePageEditStarted());
@@ -211,23 +211,15 @@ class _ProfilePageState extends State<ProfilePage> {
       ),
     );
   }
+}
 
-  _buildTextFormField(String text, bool editing, TextEditingController controller) {
-    return TextFormField(
-      controller: controller,
-      enabled: editing,
-      decoration: InputDecoration(
-        labelText: text,
-        border: UnderlineInputBorder(),
-      ),
-    );
-  }
-
-  Future<void> showloader(BuildContext context) {
-    return showDialog(
-      context: context,
-      barrierDismissible: false,
-      child: LoadingIndicator(),
-    );
-  }
+_buildTextFormField(String text, bool editing, TextEditingController controller) {
+  return TextFormField(
+    controller: controller,
+    enabled: editing,
+    decoration: InputDecoration(
+      labelText: text,
+      border: UnderlineInputBorder(),
+    ),
+  );
 }

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -32,7 +32,7 @@ class _RelationPageState extends State<RelationPage> {
         ),
         body: BlocListener<RelationPageBloc, RelationPageState>(
           listener: (context, state) {
-            if (state.message != null) {
+            if (state.message != null && state is RelationPageSuccess) {
               context.showSnackBar(state.message);
               Navigator.of(context).pop();
             }

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -34,6 +34,7 @@ class _RelationPageState extends State<RelationPage> {
           listener: (context, state) {
             if (state.message != null) {
               context.showSnackBar(state.message);
+              Navigator.of(context).pop();
             }
           },
           child: BlocBuilder<RelationPageBloc, RelationPageState>(
@@ -152,6 +153,7 @@ class _RelationPageState extends State<RelationPage> {
                           onPressed: () {
                             bloc.add(TaskDeleted(state.relation, task.id));
                             Navigator.of(context).pop();
+                            showProgressIndicator(context);
                           },
                         )
                       ],
@@ -163,8 +165,8 @@ class _RelationPageState extends State<RelationPage> {
                     GestureDetector(
                       onTap: () {
                         if (!task.isDone) {
-                          context.toast("hey");
                           bloc.add(TaskCompleted(state.relation, task.id));
+                          showProgressIndicator(context);
                         } else
                           context.toast("Task already achieved.");
                       },
@@ -215,6 +217,7 @@ class _RelationPageState extends State<RelationPage> {
                   );
 
                   Navigator.of(context).pop();
+                  showProgressIndicator(context);
                 },
               )
             ],

--- a/lib/screens/member_profile/member_profile.dart
+++ b/lib/screens/member_profile/member_profile.dart
@@ -3,6 +3,7 @@ import 'package:mentorship_client/remote/models/user.dart';
 import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/screens/member_profile/user_data_list.dart';
 import 'package:mentorship_client/screens/send_request/send_request_screen.dart';
+import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 class MemberProfileScreen extends StatelessWidget {
   final User user;
@@ -53,8 +54,9 @@ class MemberProfileScreen extends StatelessWidget {
                     style: TextStyle(color: Colors.white),
                   ),
                   onPressed: () async {
+                    showProgressIndicator(context);
                     var currentUser = await UserRepository.instance.getCurrentUser();
-
+                    Navigator.of(context).pop();
                     Navigator.of(context).push(
                       PageRouteBuilder(
                         pageBuilder: (c, anim1, anim2) => SendRequestScreen(

--- a/lib/screens/register/register_screen.dart
+++ b/lib/screens/register/register_screen.dart
@@ -4,6 +4,7 @@ import 'package:mentorship_client/extensions/context.dart';
 import 'package:mentorship_client/failure.dart';
 import 'package:mentorship_client/remote/repositories/auth_repository.dart';
 import 'package:mentorship_client/remote/requests/register.dart';
+import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 /// This screen will let the user to sign up into the system using name, username,
 /// email and password.
@@ -39,7 +40,6 @@ class RegisterForm extends StatefulWidget {
 }
 
 class _RegisterFormState extends State<RegisterForm> {
-  
   final _formKey = GlobalKey<FormState>();
 
   final _nameController = TextEditingController();
@@ -53,6 +53,9 @@ class _RegisterFormState extends State<RegisterForm> {
   bool _needsMentoring = false;
   bool _acceptedTermsAndConditions = false;
   int _radiovalue;
+  bool registering = false;
+  bool signupButtonEnabled = true;
+
   void _togglePasswordVisibility() {
     setState(() {
       _passwordVisible = !_passwordVisible;
@@ -107,7 +110,6 @@ class _RegisterFormState extends State<RegisterForm> {
   @override
   Widget build(BuildContext context) {
     const spacing = 12.0;
-
     return Form(
       key: _formKey,
       child: Column(
@@ -220,10 +222,24 @@ class _RegisterFormState extends State<RegisterForm> {
           ),
           Padding(
             padding: EdgeInsets.all(16),
-            child: RaisedButton(
-              color: Theme.of(context).accentColor,
-              child: Text("Sign up"),
-              onPressed: () => _register(context),
+            child: Column(
+              children: [
+                registering ? LoadingIndicator() : Container(),
+                RaisedButton(
+                  color: Theme.of(context).accentColor,
+                  child: Text("Sign up"),
+                  onPressed: signupButtonEnabled
+                      ? () {
+                          setState(() {
+                            registering = true;
+
+                            signupButtonEnabled = false;
+                          });
+                          _register(context);
+                        }
+                      : null,
+                ),
+              ],
             ),
           ),
           Padding(
@@ -262,5 +278,9 @@ class _RegisterFormState extends State<RegisterForm> {
       message = exception.toString();
     }
     context.showSnackBar(message);
+    setState(() {
+      registering = false;
+      signupButtonEnabled = true;
+    });
   }
 }

--- a/lib/screens/send_request/bloc/send_request_bloc.dart
+++ b/lib/screens/send_request/bloc/send_request_bloc.dart
@@ -29,12 +29,7 @@ class SendRequestBloc extends Bloc<SendRequestEvent, SendRequestState> {
       }
     }
     if (event is ResetSnackbarMessage) {
-      try {
-        yield InitialSendRequestState(message: null);
-      } on Failure catch (failure) {
-        Logger.root.severe("SendRequestBloc: ${failure.message}");
-        yield InitialSendRequestState(message: failure.message);
-      }
+      yield InitialSendRequestState(message: null);
     }
   }
 }

--- a/lib/screens/send_request/bloc/send_request_bloc.dart
+++ b/lib/screens/send_request/bloc/send_request_bloc.dart
@@ -28,5 +28,13 @@ class SendRequestBloc extends Bloc<SendRequestEvent, SendRequestState> {
         yield InitialSendRequestState(message: failure.message);
       }
     }
+    if (event is ResetSnackbarMessage) {
+      try {
+        yield InitialSendRequestState(message: null);
+      } on Failure catch (failure) {
+        Logger.root.severe("SendRequestBloc: ${failure.message}");
+        yield InitialSendRequestState(message: failure.message);
+      }
+    }
   }
 }

--- a/lib/screens/send_request/bloc/send_request_event.dart
+++ b/lib/screens/send_request/bloc/send_request_event.dart
@@ -16,5 +16,5 @@ class RelationRequestSent extends SendRequestEvent {
 
 class ResetSnackbarMessage extends SendRequestEvent {
   @override
-  List<Object> get props => throw UnimplementedError();
+  List<Object> get props => null;
 }

--- a/lib/screens/send_request/bloc/send_request_event.dart
+++ b/lib/screens/send_request/bloc/send_request_event.dart
@@ -13,3 +13,8 @@ class RelationRequestSent extends SendRequestEvent {
   @override
   List<Object> get props => [request];
 }
+
+class ResetSnackbarMessage extends SendRequestEvent {
+  @override
+  List<Object> get props => throw UnimplementedError();
+}

--- a/lib/screens/send_request/bloc/send_request_state.dart
+++ b/lib/screens/send_request/bloc/send_request_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 abstract class SendRequestState extends Equatable {
-  String message;
+  final String message;
 
   SendRequestState({this.message});
 

--- a/lib/screens/send_request/bloc/send_request_state.dart
+++ b/lib/screens/send_request/bloc/send_request_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 abstract class SendRequestState extends Equatable {
-  final String message;
+  String message;
 
   SendRequestState({this.message});
 

--- a/lib/screens/send_request/send_request_screen.dart
+++ b/lib/screens/send_request/send_request_screen.dart
@@ -29,6 +29,8 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
 
   @override
   Widget build(BuildContext context) {
+    //ignore: close_sinks
+
     return BlocProvider<SendRequestBloc>(
       create: (context) => SendRequestBloc(relationRepository: RelationRepository.instance),
       child: Scaffold(
@@ -40,7 +42,7 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
             if (state.message != null) {
               context.showSnackBar(state.message);
               Navigator.of(context).pop();
-              state.message = null;
+              BlocProvider.of<SendRequestBloc>(context).add(ResetSnackbarMessage());
             }
           },
           child: Builder(
@@ -128,7 +130,7 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
                         lastDate:
                             DateTime(initialDate.year, initialDate.month, initialDate.day + 168),
                       );
-                      if(newlySelectedDate != null){
+                      if (newlySelectedDate != null) {
                         setState(() {
                           _endDate = newlySelectedDate;
                         });

--- a/lib/screens/send_request/send_request_screen.dart
+++ b/lib/screens/send_request/send_request_screen.dart
@@ -6,6 +6,7 @@ import 'package:mentorship_client/remote/models/user.dart';
 import 'package:mentorship_client/remote/repositories/relation_repository.dart';
 import 'package:mentorship_client/remote/requests/relation_requests.dart';
 import 'package:mentorship_client/screens/send_request/bloc/bloc.dart';
+import 'package:mentorship_client/widgets/loading_indicator.dart';
 import 'package:toast/toast.dart';
 
 class SendRequestScreen extends StatefulWidget {
@@ -38,6 +39,8 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
           listener: (context, state) {
             if (state.message != null) {
               context.showSnackBar(state.message);
+              Navigator.of(context).pop();
+              state.message = null;
             }
           },
           child: Builder(
@@ -151,6 +154,7 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
                     ),
                     color: Theme.of(context).accentColor,
                     onPressed: () async {
+                      showProgressIndicator(context);
                       int mentorId = widget.otherUser.id;
                       int menteeId = widget.currentUser.id;
                       if (_role == Role.mentor) {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -128,6 +128,7 @@ class SettingsScreen extends StatelessWidget {
   Future<void> showloader(BuildContext context) {
     return showDialog(
       context: context,
+      barrierDismissible: false,
       child: LoadingIndicator(),
     );
   }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -80,11 +80,11 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
-  Future<void> _showChangePasswordDialog(BuildContext topcontext) async {
+  Future<void> _showChangePasswordDialog(BuildContext topContext) async {
     final _currentPassController = TextEditingController();
     final _newPassController = TextEditingController();
     showDialog(
-      context: topcontext,
+      context: topContext,
       builder: (context) => AlertDialog(
         title: Text("Change password"),
         content: Column(
@@ -113,11 +113,11 @@ class SettingsScreen extends StatelessWidget {
               try {
                 CustomResponse response =
                     await UserRepository.instance.changePassword(changePassword);
-                topcontext.showSnackBar(response.message);
+                topContext.showSnackBar(response.message);
               } on Failure catch (failure) {
-                topcontext.showSnackBar(failure.message);
+                topContext.showSnackBar(failure.message);
               }
-              Navigator.of(topcontext).pop();
+              Navigator.of(topContext).pop();
             },
           ),
         ],

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/remote/requests/change_password.dart';
 import 'package:mentorship_client/remote/responses/custom_response.dart';
 import 'package:mentorship_client/screens/settings/about.dart';
+import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override
@@ -52,41 +53,41 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
-  void _showConfirmLogoutDialog(BuildContext context){
+  void _showConfirmLogoutDialog(BuildContext context) {
     showDialog(
-      context: context,
-      builder:(context) {
-        return AlertDialog(
-          title : Text('Log Out'),
-          content: Text('Are you sure you want to logout?'),
-          actions: <Widget>[
-            FlatButton(
-              child: Text('Cancel'),
-              onPressed: ()=> Navigator.of(context).pop(),),
-            FlatButton(
-              child: Text('Confirm'),
-              onPressed: () {
-                BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: Text('Log Out'),
+            content: Text('Are you sure you want to logout?'),
+            actions: <Widget>[
+              FlatButton(
+                child: Text('Cancel'),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              FlatButton(
+                child: Text('Confirm'),
+                onPressed: () {
+                  BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
 
-                Navigator.of(context).pop();
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      }
-    );
+                  Navigator.of(context).pop();
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        });
   }
 
-  Future<void> _showChangePasswordDialog(BuildContext context) async {
+  Future<void> _showChangePasswordDialog(BuildContext theContext) async {
     final _currentPassController = TextEditingController();
     final _newPassController = TextEditingController();
-
     showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
+      context: theContext,
+      builder: (BuildContext context) => AlertDialog(
         title: Text("Change password"),
         content: Column(
+          // Then, the content of your dialog.
           mainAxisSize: MainAxisSize.min,
           children: [
             TextFormField(
@@ -107,20 +108,27 @@ class SettingsScreen extends StatelessWidget {
                 currentPassword: _currentPassController.text,
                 newPassword: _newPassController.text,
               );
+              Navigator.of(context).pop();
+              showloader(context);
               try {
                 CustomResponse response =
                     await UserRepository.instance.changePassword(changePassword);
-                context.showSnackBar(response.message);
+                theContext.showSnackBar(response.message);
               } on Failure catch (failure) {
-                context.showSnackBar(failure.message);
+                theContext.showSnackBar(failure.message);
               }
-
-              Navigator.of(context).pop();
+              Navigator.of(theContext).pop();
             },
           ),
         ],
       ),
+    );
+  }
 
+  Future<void> showloader(BuildContext context) {
+    return showDialog(
+      context: context,
+      child: LoadingIndicator(),
     );
   }
 }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -80,11 +80,11 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
-  Future<void> _showChangePasswordDialog(BuildContext theContext) async {
+  Future<void> _showChangePasswordDialog(BuildContext topcontext) async {
     final _currentPassController = TextEditingController();
     final _newPassController = TextEditingController();
     showDialog(
-      context: theContext,
+      context: topcontext,
       builder: (context) => AlertDialog(
         title: Text("Change password"),
         content: Column(
@@ -109,27 +109,19 @@ class SettingsScreen extends StatelessWidget {
                 newPassword: _newPassController.text,
               );
               Navigator.of(context).pop();
-              showloader(context);
+              showProgressIndicator(context);
               try {
                 CustomResponse response =
                     await UserRepository.instance.changePassword(changePassword);
-                theContext.showSnackBar(response.message);
+                topcontext.showSnackBar(response.message);
               } on Failure catch (failure) {
-                theContext.showSnackBar(failure.message);
+                topcontext.showSnackBar(failure.message);
               }
-              Navigator.of(theContext).pop();
+              Navigator.of(topcontext).pop();
             },
           ),
         ],
       ),
-    );
-  }
-
-  Future<void> showloader(BuildContext context) {
-    return showDialog(
-      context: context,
-      barrierDismissible: false,
-      child: LoadingIndicator(),
     );
   }
 }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -55,28 +55,29 @@ class SettingsScreen extends StatelessWidget {
 
   void _showConfirmLogoutDialog(BuildContext context) {
     showDialog(
-        context: context,
-        builder: (context) {
-          return AlertDialog(
-            title: Text('Log Out'),
-            content: Text('Are you sure you want to logout?'),
-            actions: <Widget>[
-              FlatButton(
-                child: Text('Cancel'),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-              FlatButton(
-                child: Text('Confirm'),
-                onPressed: () {
-                  BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Log Out'),
+          content: Text('Are you sure you want to logout?'),
+          actions: <Widget>[
+            FlatButton(
+              child: Text('Cancel'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            FlatButton(
+              child: Text('Confirm'),
+              onPressed: () {
+                BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
 
-                  Navigator.of(context).pop();
-                  Navigator.of(context).pop();
-                },
-              ),
-            ],
-          );
-        });
+                Navigator.of(context).pop();
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Future<void> _showChangePasswordDialog(BuildContext theContext) async {
@@ -84,10 +85,9 @@ class SettingsScreen extends StatelessWidget {
     final _newPassController = TextEditingController();
     showDialog(
       context: theContext,
-      builder: (BuildContext context) => AlertDialog(
+      builder: (context) => AlertDialog(
         title: Text("Change password"),
         content: Column(
-          // Then, the content of your dialog.
           mainAxisSize: MainAxisSize.min,
           children: [
             TextFormField(

--- a/lib/widgets/loading_indicator.dart
+++ b/lib/widgets/loading_indicator.dart
@@ -9,3 +9,11 @@ class LoadingIndicator extends StatelessWidget {
     );
   }
 }
+
+Future<void> showProgressIndicator(BuildContext context) {
+  return showDialog(
+    context: context,
+    barrierDismissible: false,
+    child: LoadingIndicator(),
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -552,7 +552,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.16"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.2.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.8"
+    version: "0.39.7"
   archive:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.7"
+    version: "1.3.5"
   build_runner:
     dependency: "direct dev"
     description:
@@ -112,7 +112,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "7.0.9"
   charcode:
     dependency: transitive
     description:
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.4"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   code_builder:
     dependency: transitive
     description:
@@ -196,7 +203,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.4"
   equatable:
     dependency: "direct main"
     description:
@@ -210,7 +217,14 @@ packages:
       name: expandable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.4"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   fixnum:
     dependency: transitive
     description:
@@ -281,7 +295,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.0+4"
   http_multi_server:
     dependency: transitive
     description:
@@ -379,7 +393,7 @@ packages:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.1+2"
   package_config:
     dependency: transitive
     description:
@@ -400,7 +414,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.7.0"
   pedantic:
     dependency: transitive
     description:
@@ -414,7 +428,14 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.2"
+  platform_detect:
+    dependency: transitive
+    description:
+      name: platform_detect
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -435,7 +456,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -559,28 +580,28 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.5"
+    version: "5.4.10"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+5"
+    version: "0.0.1+7"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.7"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+4"
+    version: "0.1.1+6"
   vector_math:
     dependency: transitive
     description:
@@ -594,7 +615,7 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "0.9.7+14"
   web_socket_channel:
     dependency: transitive
     description:
@@ -608,14 +629,14 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "3.7.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
### Description
Add loading indicator on screen to help user understand what's happening.
If a user has a slow internet connection, the changing password request can take long and without a loading indicator he/she might think the apps stuck. Loading indicators will tell that the process is currently going on  
Fixes #67
Fixes #94

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?

Physical device. Check gif below
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/52817235/82616814-e8963780-9beb-11ea-90ce-27e8a07d1e27.gif)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
