### PR TITLE
fix: #39 onclick cancel button on send request calander widget

### DIFF
--- a/lib/screens/send_request/send_request_screen.dart
+++ b/lib/screens/send_request/send_request_screen.dart
@@ -125,10 +125,11 @@ class _SendRequestScreenState extends State<SendRequestScreen> {
                         lastDate:
                             DateTime(initialDate.year, initialDate.month, initialDate.day + 168),
                       );
-
-                      setState(() {
-                        _endDate = newlySelectedDate;
-                      });
+                      if(newlySelectedDate != null){
+                        setState(() {
+                          _endDate = newlySelectedDate;
+                        });
+                      }
                     },
                     icon: Icon(Icons.calendar_today),
                   ),


### PR DESCRIPTION
### Description
When cancel button is pressed it returns a null value in newlySelectedDate which has to be checked before using the value. So I've included a check condition.

Fixes #39 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
After change:
![Record-2020-06-03-13-38-52-92746](https://user-images.githubusercontent.com/34762451/83616085-07f67280-a5a5-11ea-9461-a654e59ee03d.gif)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings