### PR TITLE
feat: add confirm password field and show passwords feature to change password popUp

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -169,20 +169,22 @@ class SettingsScreen extends StatelessWidget {
               FlatButton(
                 child: Text("Submit"),
                 onPressed: () async {
-                  ChangePassword changePassword = ChangePassword(
-                    currentPassword: _currentPassController.text,
-                    newPassword: _newPassController.text,
-                  );
-                  Navigator.of(context).pop();
-                  showProgressIndicator(context);
-                  try {
-                    CustomResponse response =
-                        await UserRepository.instance.changePassword(changePassword);
-                    topContext.showSnackBar(response.message);
-                  } on Failure catch (failure) {
-                    topContext.showSnackBar(failure.message);
+                  if (_formKey.currentState.validate()) {
+                    ChangePassword changePassword = ChangePassword(
+                      currentPassword: _currentPassController.text,
+                      newPassword: _newPassController.text,
+                    );
+                    Navigator.of(context).pop();
+                    showProgressIndicator(context);
+                    try {
+                      CustomResponse response =
+                          await UserRepository.instance.changePassword(changePassword);
+                      topContext.showSnackBar(response.message);
+                    } on Failure catch (failure) {
+                      topContext.showSnackBar(failure.message);
+                    }
+                    Navigator.of(topContext).pop();
                   }
-                  Navigator.of(topContext).pop();
                 },
               ),
             ],

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -57,15 +57,15 @@ class SettingsScreen extends StatelessWidget {
         context: context,
         builder: (context) {
           return AlertDialog(
-            title: Text('Log Out'),
+            title: Text("Log Out"),
             content: Text('Are you sure you want to logout?'),
             actions: <Widget>[
               FlatButton(
-                child: Text('Cancel'),
+                child: Text("Cancel"),
                 onPressed: () => Navigator.of(context).pop(),
               ),
               FlatButton(
-                child: Text('Confirm'),
+                child: Text("Confirm"),
                 onPressed: () {
                   BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
 

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -52,75 +52,110 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
-  void _showConfirmLogoutDialog(BuildContext context){
+  void _showConfirmLogoutDialog(BuildContext context) {
     showDialog(
-      context: context,
-      builder:(context) {
-        return AlertDialog(
-          title : Text('Log Out'),
-          content: Text('Are you sure you want to logout?'),
-          actions: <Widget>[
-            FlatButton(
-              child: Text('Cancel'),
-              onPressed: ()=> Navigator.of(context).pop(),),
-            FlatButton(
-              child: Text('Confirm'),
-              onPressed: () {
-                BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: Text('Log Out'),
+            content: Text('Are you sure you want to logout?'),
+            actions: <Widget>[
+              FlatButton(
+                child: Text('Cancel'),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              FlatButton(
+                child: Text('Confirm'),
+                onPressed: () {
+                  BlocProvider.of<AuthBloc>(context).add(JustLoggedOut());
 
-                Navigator.of(context).pop();
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      }
-    );
+                  Navigator.of(context).pop();
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        });
   }
 
   Future<void> _showChangePasswordDialog(BuildContext context) async {
     final _currentPassController = TextEditingController();
     final _newPassController = TextEditingController();
+    final _newPassConfirmController = TextEditingController();
+    bool _passwordVisible = false;
 
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text("Change password"),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextFormField(
-              controller: _currentPassController,
-              decoration: InputDecoration(labelText: "Current password"),
-            ),
-            TextFormField(
-              controller: _newPassController,
-              decoration: InputDecoration(labelText: "New password"),
-            ),
-          ],
-        ),
-        actions: [
-          FlatButton(
-            child: Text("Submit"),
-            onPressed: () async {
-              ChangePassword changePassword = ChangePassword(
-                currentPassword: _currentPassController.text,
-                newPassword: _newPassController.text,
-              );
-              try {
-                CustomResponse response =
-                    await UserRepository.instance.changePassword(changePassword);
-                context.showSnackBar(response.message);
-              } on Failure catch (failure) {
-                context.showSnackBar(failure.message);
-              }
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) {
+          void _togglePassVisibility() {
+            setState(() {
+              _passwordVisible = !_passwordVisible;
+            });
+          }
 
-              Navigator.of(context).pop();
-            },
-          ),
-        ],
+          return AlertDialog(
+            title: Text("Change password"),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: _currentPassController,
+                  decoration: InputDecoration(labelText: "Current password"),
+                ),
+                TextFormField(
+                  controller: _newPassController,
+                  decoration: InputDecoration(
+                    labelText: "New password",
+                    suffixIcon: IconButton(
+                      icon: Icon(_passwordVisible ? Icons.visibility : Icons.visibility_off),
+                      onPressed: _togglePassVisibility,
+                    ),
+                  ),
+                  obscureText: !_passwordVisible,
+                ),
+                TextFormField(
+                  controller: _newPassConfirmController,
+                  decoration: InputDecoration(
+                    labelText: "Confirm password",
+                    suffixIcon: IconButton(
+                      icon: Icon(_passwordVisible ? Icons.visibility : Icons.visibility_off),
+                      onPressed: _togglePassVisibility,
+                    ),
+                  ),
+                  obscureText: !_passwordVisible
+                  ,
+                )
+              ],
+            ),
+            actions: [
+              FlatButton(
+                child: Text("Submit"),
+                onPressed: () async {
+                  if (_newPassConfirmController.text != _newPassController.text) {
+                    _newPassController.clear();
+                    _newPassConfirmController.clear();
+                  } else {
+                    ChangePassword changePassword = ChangePassword(
+                      currentPassword: _currentPassController.text,
+                      newPassword: _newPassController.text,
+                    );
+                    try {
+                      CustomResponse response =
+                          await UserRepository.instance.changePassword(changePassword);
+                      context.showSnackBar(response.message);
+                    } on Failure catch (failure) {
+                      context.showSnackBar(failure.message);
+                    }
+
+                    Navigator.of(context).pop();
+                  }
+                },
+              ),
+            ],
+          );
+        },
       ),
-
     );
   }
 }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/remote/requests/change_password.dart';
 import 'package:mentorship_client/remote/responses/custom_response.dart';
 import 'package:mentorship_client/screens/settings/about.dart';
+import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override
@@ -169,12 +170,14 @@ class SettingsScreen extends StatelessWidget {
                       currentPassword: _currentPassController.text,
                       newPassword: _newPassController.text,
                     );
+                    Navigator.of(context).pop();
+                    showProgressIndicator(context);
                     try {
                       CustomResponse response =
                           await UserRepository.instance.changePassword(changePassword);
-                      context.showSnackBar(response.message);
+                      topContext.showSnackBar(response.message);
                     } on Failure catch (failure) {
-                      context.showSnackBar(failure.message);
+                      topContext.showSnackBar(failure.message);
                     }
 
                     Navigator.of(context).pop();

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -179,8 +179,7 @@ class SettingsScreen extends StatelessWidget {
                     } on Failure catch (failure) {
                       topContext.showSnackBar(failure.message);
                     }
-
-                    Navigator.of(context).pop();
+                    Navigator.of(topContext).pop();
                   }
                 },
               ),

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -83,9 +83,7 @@ class SettingsScreen extends StatelessWidget {
     final _newPassController = TextEditingController();
     final _newPassConfirmController = TextEditingController();
     final _formKey = GlobalKey<FormState>();
-    bool _newPasswordVisible = false;
-    bool _currentPasswordVisible = false;
-    bool _confirmPasswordVisible = false;
+    bool _passwordVisible = false;
 
     String _validatePasswords(String password) {
       if (password.isEmpty) {
@@ -108,87 +106,83 @@ class SettingsScreen extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: Text("Change password"),
-          content: Form(
-            key: _formKey,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                TextFormField(
-                  controller: _currentPassController,
-                  decoration: InputDecoration(
-                    labelText: "Current password",
-                    suffixIcon: IconButton(
-                      icon: Icon(_currentPasswordVisible ? Icons.visibility : Icons.visibility_off),
-                      onPressed: () {
-                        setState(() {
-                          _currentPasswordVisible = !_currentPasswordVisible;
-                        });
-                      },
-                    ),
-                  ),
-                  validator: (value) => _validatePasswords(value),
-                  obscureText: !_currentPasswordVisible,
-                ),
-                TextFormField(
-                  controller: _newPassController,
-                  decoration: InputDecoration(
-                    labelText: "New password",
-                    suffixIcon: IconButton(
-                      icon: Icon(_newPasswordVisible ? Icons.visibility : Icons.visibility_off),
-                      onPressed: () {
-                        setState(() {
-                          _newPasswordVisible = !_newPasswordVisible;
-                        });
-                      },
-                    ),
-                  ),
-                  validator: (value) => _validatePasswords(value),
-                  obscureText: !_newPasswordVisible,
-                ),
-                TextFormField(
-                  controller: _newPassConfirmController,
-                  decoration: InputDecoration(
-                    labelText: "Confirm password",
-                    suffixIcon: IconButton(
-                      icon: Icon(_confirmPasswordVisible ? Icons.visibility : Icons.visibility_off),
-                      onPressed: () {
-                        setState(() {
-                          _confirmPasswordVisible = !_confirmPasswordVisible;
-                        });
-                      },
-                    ),
-                  ),
-                  obscureText: !_confirmPasswordVisible,
-                  validator: (value) => _validateConfirmPass(value),
-                ),
-              ],
-            ),
-          ),
-          actions: [
-            FlatButton(
-              child: Text("Submit"),
-              onPressed: () async {
-                if (_formKey.currentState.validate()) {
-                  ChangePassword changePassword = ChangePassword(
-                    currentPassword: _currentPassController.text,
-                    newPassword: _newPassController.text,
-                  );
-                  try {
-                    CustomResponse response =
-                        await UserRepository.instance.changePassword(changePassword);
-                    context.showSnackBar(response.message);
-                  } on Failure catch (failure) {
-                    context.showSnackBar(failure.message);
-                  }
+        builder: (context, setState) {
+          void _togglePasswordVisibility() {
+            setState(() {
+              _passwordVisible = !_passwordVisible;
+            });
+          }
 
-                  Navigator.of(context).pop();
-                }
-              },
+          return AlertDialog(
+            title: Text("Change password"),
+            content: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: _currentPassController,
+                    decoration: InputDecoration(
+                      labelText: "Current password",
+                      suffixIcon: IconButton(
+                        icon: Icon(_passwordVisible ? Icons.visibility : Icons.visibility_off),
+                        onPressed: _togglePasswordVisibility,
+                      ),
+                    ),
+                    validator: (value) => _validatePasswords(value),
+                    obscureText: !_passwordVisible,
+                  ),
+                  TextFormField(
+                    controller: _newPassController,
+                    decoration: InputDecoration(
+                      labelText: "New password",
+                      suffixIcon: IconButton(
+                        icon: Icon(_passwordVisible ? Icons.visibility : Icons.visibility_off),
+                        onPressed: _togglePasswordVisibility,
+                      ),
+                    ),
+                    validator: (value) => _validatePasswords(value),
+                    obscureText: !_passwordVisible,
+                  ),
+                  TextFormField(
+                    controller: _newPassConfirmController,
+                    decoration: InputDecoration(
+                      labelText: "Confirm password",
+                      suffixIcon: IconButton(
+                        icon: Icon(_passwordVisible ? Icons.visibility : Icons.visibility_off),
+                        onPressed: _togglePasswordVisibility,
+                      ),
+                    ),
+                    obscureText: !_passwordVisible,
+                    validator: (value) => _validateConfirmPass(value),
+                  ),
+                ],
+              ),
             ),
-          ],
-        ),
+            actions: [
+              FlatButton(
+                child: Text("Submit"),
+                onPressed: () async {
+                  if (_formKey.currentState.validate()) {
+                    ChangePassword changePassword = ChangePassword(
+                      currentPassword: _currentPassController.text,
+                      newPassword: _newPassController.text,
+                    );
+                    try {
+                      CustomResponse response =
+                          await UserRepository.instance.changePassword(changePassword);
+                      context.showSnackBar(response.message);
+                    } on Failure catch (failure) {
+                      context.showSnackBar(failure.message);
+                    }
+
+                    Navigator.of(context).pop();
+                  }
+                },
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -8,7 +8,6 @@ import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/remote/requests/change_password.dart';
 import 'package:mentorship_client/remote/responses/custom_response.dart';
 import 'package:mentorship_client/screens/settings/about.dart';
-import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override
@@ -106,7 +105,7 @@ class SettingsScreen extends StatelessWidget {
     }
 
     showDialog(
-      context: context,
+      context: topContext,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) {
           void _togglePasswordVisibility() {


### PR DESCRIPTION
### Description
Add confirm password field with validation and toggle password visibility button on the change password popUp

Fixes #76 

### Flutter Channel:
- [ ] I have used the Flutter Beta channel on my local machine

### Type of Change:

- Code

**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Physical Device
Steps:
- Go to the Settings page by clicking on the icon at the top right corner of the homepage.
- Click on the Change Password button to see whether the feature works properly or not
![flutter_01](https://user-images.githubusercontent.com/58745044/83939354-dfb38180-a7f9-11ea-95e5-15590673be76.png)
 

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any dependent changes have been published in downstream modules