### PR TITLE
feat: make disabled text fields appear grey on profile page

### DIFF
--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -32,7 +32,7 @@ class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStat
     context.bloc<ProfilePageBloc>()..add(ProfilePageShowed());
     _animationController = AnimationController(
       vsync: this,
-      duration: Duration(milliseconds: 400),
+      duration: Duration(milliseconds: 500),
       upperBound: 0.5,
     );
     super.initState();

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -134,123 +134,126 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Widget _createPage(BuildContext context, User user, bool editing) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: ListView(
-        shrinkWrap: true,
-        children: [
-          SizedBox(height: 24),
-          Center(
-            child: ClipOval(
-              child: Container(
-                color: Colors.deepPurple,
-                width: MediaQuery.of(context).size.width / 2,
-                height: MediaQuery.of(context).size.width / 2,
+    return Opacity(
+      opacity: editing ? 1.0 : 0.5,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            SizedBox(height: 24),
+            Center(
+              child: ClipOval(
+                child: Container(
+                  color: Colors.deepPurple,
+                  width: MediaQuery.of(context).size.width / 2,
+                  height: MediaQuery.of(context).size.width / 2,
+                ),
               ),
             ),
-          ),
-          Form(
-            key: _formKey,
-            child: Column(
-              children: [
-                Container(
-                  width: MediaQuery.of(context).size.width / 2,
-                  child: TextFormField(
-                    controller: _nameController,
-                    enabled: editing,
+            Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  Container(
+                    width: MediaQuery.of(context).size.width / 2,
+                    child: TextFormField(
+                      controller: _nameController,
+                      enabled: editing,
+                      onSaved: (value) {
+                        user.name = value;
+                      },
+                      textAlign: TextAlign.center,
+                      decoration: const InputDecoration(
+                        border: const UnderlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  TextFormField(
+                    controller: _usernameController,
+                    enabled: false,
                     onSaved: (value) {
                       user.name = value;
                     },
-                    textAlign: TextAlign.center,
                     decoration: const InputDecoration(
+                      labelText: "Username",
                       border: const UnderlineInputBorder(),
                     ),
                   ),
-                ),
-                TextFormField(
-                  controller: _usernameController,
-                  enabled: false,
-                  onSaved: (value) {
-                    user.name = value;
-                  },
-                  decoration: const InputDecoration(
-                    labelText: "Username",
-                    border: const UnderlineInputBorder(),
-                  ),
-                ),
-                TextFormField(
-                  controller: _emailController,
-                  enabled: false,
-                  onSaved: (value) {
-                    user.email = value;
-                  },
-                  decoration: const InputDecoration(
-                    labelText: "Email",
-                    border: const UnderlineInputBorder(),
-                  ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    const Text("Available to mentor"),
-                    Checkbox(
-                      value: _availableToMentor,
-                      onChanged: editing
-                          ? (value) {
-                              setState(() {
-                                _availableToMentor = value;
-                              });
-                            }
-                          : null,
+                  TextFormField(
+                    controller: _emailController,
+                    enabled: false,
+                    onSaved: (value) {
+                      user.email = value;
+                    },
+                    decoration: const InputDecoration(
+                      labelText: "Email",
+                      border: const UnderlineInputBorder(),
                     ),
-                  ],
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    const Text("Needs mentoring"),
-                    Checkbox(
-                      value: _needsMentoring,
-                      onChanged: editing
-                          ? (value) {
-                              setState(() {
-                                _needsMentoring = value;
-                              });
-                            }
-                          : null,
-                    ),
-                  ],
-                ),
-                _buildTextFormField(
-                  "Bio",
-                  editing,
-                  _bioController,
-                  (value) {
-                    user.bio = value;
-                  },
-                ),
-                _buildTextFormField("Slack username", editing, _slackController, (value) {
-                  user.slackUsername = value;
-                }),
-                _buildTextFormField("Location", editing, _locationController, (value) {
-                  user.location = value;
-                }),
-                _buildTextFormField("Occupation", editing, _occupationController, (value) {
-                  user.occupation = value;
-                }),
-                _buildTextFormField("Organization", editing, _organizationController, (value) {
-                  user.organization = value;
-                }),
-                _buildTextFormField("Skills", editing, _skillsController, (value) {
-                  user.skills = value;
-                }),
-                _buildTextFormField("Interests", editing, _interestsController, (value) {
-                  user.interests = value;
-                }),
-              ],
-            ),
-          )
-        ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text("Available to mentor"),
+                      Checkbox(
+                        value: _availableToMentor,
+                        onChanged: editing
+                            ? (value) {
+                                setState(() {
+                                  _availableToMentor = value;
+                                });
+                              }
+                            : null,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const Text("Needs mentoring"),
+                      Checkbox(
+                        value: _needsMentoring,
+                        onChanged: editing
+                            ? (value) {
+                                setState(() {
+                                  _needsMentoring = value;
+                                });
+                              }
+                            : null,
+                      ),
+                    ],
+                  ),
+                  _buildTextFormField(
+                    "Bio",
+                    editing,
+                    _bioController,
+                    (value) {
+                      user.bio = value;
+                    },
+                  ),
+                  _buildTextFormField("Slack username", editing, _slackController, (value) {
+                    user.slackUsername = value;
+                  }),
+                  _buildTextFormField("Location", editing, _locationController, (value) {
+                    user.location = value;
+                  }),
+                  _buildTextFormField("Occupation", editing, _occupationController, (value) {
+                    user.occupation = value;
+                  }),
+                  _buildTextFormField("Organization", editing, _organizationController, (value) {
+                    user.organization = value;
+                  }),
+                  _buildTextFormField("Skills", editing, _skillsController, (value) {
+                    user.skills = value;
+                  }),
+                  _buildTextFormField("Interests", editing, _interestsController, (value) {
+                    user.interests = value;
+                  }),
+                ],
+              ),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -10,7 +10,7 @@ class ProfilePage extends StatefulWidget {
   _ProfilePageState createState() => _ProfilePageState();
 }
 
-class _ProfilePageState extends State<ProfilePage> {
+class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStateMixin {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
   final _usernameController = TextEditingController(); // not changeable
@@ -25,10 +25,16 @@ class _ProfilePageState extends State<ProfilePage> {
   bool _availableToMentor;
   bool _needsMentoring;
   bool editing = false;
+  AnimationController _animationController;
 
   @override
   void initState() {
     context.bloc<ProfilePageBloc>()..add(ProfilePageShowed());
+    _animationController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 400),
+      upperBound: 0.5,
+    );
     super.initState();
   }
 
@@ -64,7 +70,9 @@ class _ProfilePageState extends State<ProfilePage> {
               user.interests = _interestsController.text;
 
               bloc.add(ProfilePageEditSubmitted(user));
+              _animationController.reverse();
             } else if (state is ProfilePageSuccess) {
+              _animationController.forward();
               bloc.add(ProfilePageEditStarted());
             }
           },
@@ -134,8 +142,14 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Widget _createPage(BuildContext context, User user, bool editing) {
-    return Opacity(
-      opacity: editing ? 1.0 : 0.5,
+    return AnimatedBuilder(
+      animation: _animationController,
+      builder: (context, child) {
+        return Opacity(
+          opacity: 0.5 + _animationController.value,
+          child: child,
+        );
+      },
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: ListView(


### PR DESCRIPTION
### Description
Added an opacity widget that sets the opacity of the page to 50% when editing is disabled and changes to 100% when editing is enabled.

Fixes #84 

### Flutter Channel:
- [ ] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Physical device.
Steps:
- Go to the profile page by selecting it from bottom bar
- Click on the Floating Action Button to start editing and see the changes

![sample](https://user-images.githubusercontent.com/58745044/84526402-dabf6800-acfa-11ea-936c-7c75767d53cd.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any dependent changes have been published in downstream modules