### PR TITLE
feat: add find members btn to empty relation screen

### DIFF
--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -78,12 +78,13 @@ class _RelationPageState extends State<RelationPage> {
                                 color: Colors.white,
                               ),
                               SizedBox(
-                                width: MediaQuery.of(context).size.width * 0.32,
+                                width: MediaQuery.of(context).size.width * 0.3,
                                 child: AutoSizeText(
                                   "Find members",
                                   style: TextStyle(
                                     color: Colors.white,
                                   ),
+                                  textAlign: TextAlign.center,
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               ),

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -4,6 +4,8 @@ import 'package:mentorship_client/extensions/context.dart';
 import 'package:mentorship_client/extensions/datetime.dart';
 import 'package:mentorship_client/remote/models/task.dart';
 import 'package:mentorship_client/remote/requests/task_request.dart';
+import 'package:mentorship_client/screens/home/bloc/bloc.dart';
+import 'package:mentorship_client/screens/home/bloc/home_bloc.dart';
 import 'package:mentorship_client/screens/home/pages/relation/bloc/bloc.dart';
 import 'package:mentorship_client/widgets/bold_text.dart';
 import 'package:mentorship_client/widgets/loading_indicator.dart';
@@ -49,7 +51,44 @@ class _RelationPageState extends State<RelationPage> {
 
               if (state is RelationPageFailure) {
                 return Center(
-                  child: Text(state.message),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(state.message),
+                      SizedBox(
+                        height: MediaQuery.of(context).size.height / 40,
+                      ),
+                      Container(
+                        height: MediaQuery.of(context).size.height / 17,
+                        width: MediaQuery.of(context).size.width * 0.35,
+                        child: RaisedButton(
+                          color: Theme.of(context).accentColor,
+                          onPressed: () {
+                            //ignore: close_sinks
+                            final bloc = BlocProvider.of<HomeBloc>(context);
+
+                            bloc.add(MembersPageSelected());
+                          },
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.search,
+                                color: Colors.white,
+                              ),
+                              Flexible(
+                                  child: Text(
+                                "Find members",
+                                maxLines: 1,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              )),
+                            ],
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
                 );
               }
 

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -9,6 +9,7 @@ import 'package:mentorship_client/screens/home/bloc/home_bloc.dart';
 import 'package:mentorship_client/screens/home/pages/relation/bloc/bloc.dart';
 import 'package:mentorship_client/widgets/bold_text.dart';
 import 'package:mentorship_client/widgets/loading_indicator.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 
 class RelationPage extends StatefulWidget {
   @override
@@ -60,7 +61,7 @@ class _RelationPageState extends State<RelationPage> {
                       ),
                       Container(
                         height: MediaQuery.of(context).size.height / 17,
-                        width: MediaQuery.of(context).size.width * 0.35,
+                        width: MediaQuery.of(context).size.width * 0.47,
                         child: RaisedButton(
                           color: Theme.of(context).accentColor,
                           onPressed: () {
@@ -70,18 +71,22 @@ class _RelationPageState extends State<RelationPage> {
                             bloc.add(MembersPageSelected());
                           },
                           child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Icon(
                                 Icons.search,
                                 color: Colors.white,
                               ),
-                              Flexible(
-                                  child: Text(
-                                "Find members",                                
-                                style: TextStyle(
-                                  color: Colors.white,
+                              SizedBox(
+                                width: MediaQuery.of(context).size.width * 0.32,
+                                child: AutoSizeText(
+                                  "Find members",
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
                                 ),
-                              )),
+                              ),
                             ],
                           ),
                         ),

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -77,8 +77,7 @@ class _RelationPageState extends State<RelationPage> {
                               ),
                               Flexible(
                                   child: Text(
-                                "Find members",
-                                maxLines: 1,
+                                "Find members",                                
                                 style: TextStyle(
                                   color: Colors.white,
                                 ),

--- a/lib/screens/register/register_screen.dart
+++ b/lib/screens/register/register_screen.dart
@@ -39,7 +39,6 @@ class RegisterForm extends StatefulWidget {
 }
 
 class _RegisterFormState extends State<RegisterForm> {
-  
   final _formKey = GlobalKey<FormState>();
 
   final _nameController = TextEditingController();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,7 +545,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.16"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.1"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   bloc:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   package_info: ^0.4.0+17
   url_launcher: ^5.4.5
   expandable: ^4.1.3
-
+  auto_size_text: ^2.1.0
   # Bloc
   bloc: ^4.0.0
   flutter_bloc: ^4.0.0


### PR DESCRIPTION
### Description
Relation screen now shows find members when you aren't in a relation :)

Fixes #41 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- User Interface

### How Has This Been Tested?
Physical device, check  gif below.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/52817235/85217438-b88ab180-b3ae-11ea-991e-35067c176edc.gif)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
