### PR TITLE
fix: Persist data

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -16,20 +16,33 @@ import 'package:mentorship_client/screens/home/pages/stats/stats_page.dart';
 import 'package:mentorship_client/screens/settings/settings_screen.dart';
 import 'package:toast/toast.dart';
 
+import 'pages/members/bloc/members_page_bloc.dart';
+import 'pages/members/bloc/members_page_event.dart';
+import 'pages/stats/bloc/stats_page_bloc.dart';
+import 'pages/stats/bloc/stats_page_event.dart';
+
 /// [HomeScreen] is the main screen in the app. It's what user sees after successfully logging in.
 /// HomeScreen's main task is to have scaffold with AppBar and BottomNavBar. Content (i.e body)
 /// is provided by one of 5 Pages - [StatsPage], [ProfilePage], [RelationPage], [MembersPage] and [RequestsPage].
 /// HomeScreen manages displaying of these pages using BottomNavBar and PageView.
-class HomeScreen extends StatelessWidget {
-  final pageController = PageController();
+class HomeScreen extends StatefulWidget {
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
 
+class _HomeScreenState extends State<HomeScreen> {
+  final pageController = PageController();
+  int _currentIndex = 0;
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
         // I think its too high in the widget tree, but I couldn't find a better solution
+
         BlocProvider<ProfilePageBloc>(
-          create: (context) => ProfilePageBloc(userRepository: UserRepository.instance),
+          create: (context) =>
+              ProfilePageBloc(userRepository: UserRepository.instance)..add(ProfilePageShowed()),
+          child: ProfilePage(),
         ),
         BlocProvider<HomeBloc>(
           create: (context) => HomeBloc(),
@@ -38,12 +51,26 @@ class HomeScreen extends StatelessWidget {
           create: (context) => RelationPageBloc(
             relationRepository: RelationRepository.instance,
             taskRepository: TaskRepository.instance,
-          ),
+          )..add(RelationPageShowed()),
+          child: RelationPage(),
         ),
         BlocProvider<RequestsPageBloc>(
           create: (context) => RequestsPageBloc(
             relationRepository: RelationRepository.instance,
-          ),
+          )..add(RequestsPageShowed()),
+          child: RequestsPage(),
+        ),
+
+        BlocProvider<StatsPageBloc>(
+          create: (context) => StatsPageBloc(userRepository: UserRepository.instance)
+            ..add(
+              StatsPageShowed(),
+            ),
+        ),
+        BlocProvider<MembersPageBloc>(
+          create: (context) =>
+              MembersPageBloc(userRepository: UserRepository.instance)..add(MembersPageShowed()),
+          child: MembersPage(),
         ),
       ],
       child: BlocListener<HomeBloc, HomeState>(
@@ -84,11 +111,11 @@ class HomeScreen extends StatelessWidget {
                 ],
               ),
               bottomNavigationBar: BottomNavyBar(
-                showElevation: false,
-                onItemSelected:
-                    (index) => // This triggers when the user clicks item on BottomNavyBar
-                        BlocProvider.of<HomeBloc>(context).add(HomeEvent.fromIndex(index)),
-                selectedIndex: state.index,
+                selectedIndex: _currentIndex,
+                onItemSelected: (index) {
+                  setState(() => _currentIndex = index);
+                  pageController.jumpToPage(index);
+                },
                 items: [
                   BottomNavyBarItem(
                     icon: Icon(Icons.home),

--- a/lib/screens/home/pages/members/bloc/members_page_bloc.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_bloc.dart
@@ -46,7 +46,7 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
                 );
         }
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("MembersPageBloc: Failure catched: $failure.message");
         yield MembersPageFailure(failure.message);
       }
     }
@@ -61,7 +61,7 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
         final List<User> users = await userRepository.getVerifiedUsers(pageNumber);
         yield MembersPageSuccess(users: users, hasReachedMax: false);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("MembersPageBloc: Failure catched: $failure.message");
         yield state;
       }
     }

--- a/lib/screens/home/pages/members/bloc/members_page_bloc.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_bloc.dart
@@ -60,7 +60,8 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
         yield MembersPageLoading();
         final List<User> users = await userRepository.getVerifiedUsers(pageNumber);
         yield MembersPageSuccess(users: users, hasReachedMax: false);
-      } on Failure catch (_) {
+      } on Failure catch (failure) {
+        Logger.root.severe(failure.message);
         yield state;
       }
     }

--- a/lib/screens/home/pages/members/bloc/members_page_event.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_event.dart
@@ -8,3 +8,5 @@ abstract class MembersPageEvent extends Equatable {
 }
 
 class MembersPageShowed extends MembersPageEvent {}
+
+class MembersPageRefresh extends MembersPageEvent {}

--- a/lib/screens/home/pages/members/members_page.dart
+++ b/lib/screens/home/pages/members/members_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mentorship_client/remote/models/user.dart';
@@ -15,49 +17,66 @@ class _MembersPageState extends State<MembersPage> {
   // ignore: dart.core.Sink
   MembersPageBloc _membersPageBloc;
   final _scrollThreshold = 10.0;
+  Completer<void> _refreshCompleter;
 
   @override
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
     _membersPageBloc = BlocProvider.of<MembersPageBloc>(context);
+    _refreshCompleter = Completer<void>();
   }
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<MembersPageBloc, MembersPageState>(
-      builder: (context, state) {
-        if (state is MembersPageFailure) {
-          return Center(
-            child: Text('failed to get users'),
-          );
-        }
-        if (state is MembersPageSuccess) {
-          if (state.users.isEmpty) {
+    return BlocConsumer<MembersPageBloc, MembersPageState>(listener: (context, state) {
+      if (state is MembersPageShowed) {
+        _refreshCompleter?.complete();
+        _refreshCompleter = Completer();
+      }
+    }, builder: (context, state) {
+      return BlocBuilder<MembersPageBloc, MembersPageState>(
+        builder: (context, state) {
+          if (state is MembersPageFailure) {
             return Center(
-              child: Text('no users'),
+              child: Text('failed to get users'),
             );
           }
-          return ListView.builder(
-            itemBuilder: (BuildContext context, int index) {
-              bool _reachedEnd = index > state.users.length - 1;
-              User user = (!_reachedEnd) ? state.users[index] : null;
-              return _reachedEnd
-                  ? BottomLoader()
-                  : InkWell(
-                      onTap: () => _openMemberProfileScreen(context, user),
-                      child: MemberListTile(user: user),
-                    );
-            },
-            itemCount: state.hasReachedMax ? (state.users.length) : (state.users.length + 1),
-            controller: _scrollController,
+          if (state is MembersPageSuccess) {
+            if (state.users.isEmpty) {
+              return Center(
+                child: Text('no users'),
+              );
+            }
+            return RefreshIndicator(
+              onRefresh: () {
+                BlocProvider.of<MembersPageBloc>(context).add(
+                  MembersPageRefresh(),
+                );
+                return _refreshCompleter.future;
+              },
+              child: ListView.builder(
+                itemBuilder: (BuildContext context, int index) {
+                  bool _reachedEnd = index > state.users.length - 1;
+                  User user = (!_reachedEnd) ? state.users[index] : null;
+                  return _reachedEnd
+                      ? BottomLoader()
+                      : InkWell(
+                          onTap: () => _openMemberProfileScreen(context, user),
+                          child: MemberListTile(user: user),
+                        );
+                },
+                itemCount: state.hasReachedMax ? (state.users.length) : (state.users.length + 1),
+                controller: _scrollController,
+              ),
+            );
+          }
+          return Center(
+            child: CircularProgressIndicator(),
           );
-        }
-        return Center(
-          child: CircularProgressIndicator(),
-        );
-      },
-    );
+        },
+      );
+    });
   }
 
   void _openMemberProfileScreen(BuildContext context, User user) {

--- a/lib/screens/home/pages/members/members_page.dart
+++ b/lib/screens/home/pages/members/members_page.dart
@@ -1,27 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mentorship_client/remote/models/user.dart';
-import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/screens/home/pages/members/bloc/bloc.dart';
 import 'package:mentorship_client/screens/home/pages/members/widgets/member_list_tile.dart';
 import 'package:mentorship_client/screens/member_profile/member_profile.dart';
 
-class MembersPage extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocProvider<MembersPageBloc>(
-        create: (context) =>
-            MembersPageBloc(userRepository: UserRepository.instance)..add(MembersPageShowed()),
-        child: _MembersPage());
-  }
-}
-
-class _MembersPage extends StatefulWidget {
+class MembersPage extends StatefulWidget {
   @override
   _MembersPageState createState() => _MembersPageState();
 }
 
-class _MembersPageState extends State<_MembersPage> {
+class _MembersPageState extends State<MembersPage> {
   final _scrollController = ScrollController();
   // ignore: dart.core.Sink
   MembersPageBloc _membersPageBloc;

--- a/lib/screens/home/pages/members/members_page.dart
+++ b/lib/screens/home/pages/members/members_page.dart
@@ -39,13 +39,13 @@ class _MembersPageState extends State<MembersPage> {
         builder: (context, state) {
           if (state is MembersPageFailure) {
             return Center(
-              child: Text('failed to get users'),
+              child: Text('Failed to get users'),
             );
           }
           if (state is MembersPageSuccess) {
             if (state.users.isEmpty) {
               return Center(
-                child: Text('no users'),
+                child: Text('No users'),
               );
             }
             return RefreshIndicator(

--- a/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
+++ b/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
@@ -49,7 +49,8 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
       try {
         _user = await userRepository.getCurrentUser();
         yield ProfilePageSuccess(_user, message: event.message);
-      } on Failure catch (_) {
+      } on Failure catch (failure) {
+        Logger.root.severe(failure.message);
         yield state;
       }
     }

--- a/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
+++ b/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
@@ -22,6 +22,16 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
   @override
   Stream<ProfilePageState> mapEventToState(ProfilePageEvent event) async* {
     if (event is ProfilePageShowed) {
+      yield* mapEventToProfileShowed(event);
+    } else if (event is ProfilePageRefresh) {
+      yield* mapEventToRefreshRequested(event);
+    } else {
+      yield* mapEventToProfileEditing(event);
+    }
+  }
+
+  Stream<ProfilePageState> mapEventToProfileShowed(ProfilePageEvent event) async* {
+    if (event is ProfilePageShowed) {
       yield ProfilePageLoading();
       try {
         _user = await userRepository.getCurrentUser();
@@ -31,6 +41,21 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
         yield ProfilePageFailure(message: failure.message);
       }
     }
+  }
+
+  Stream<ProfilePageState> mapEventToRefreshRequested(ProfilePageEvent event) async* {
+    if (event is ProfilePageRefresh) {
+      yield ProfilePageLoading();
+      try {
+        _user = await userRepository.getCurrentUser();
+        yield ProfilePageSuccess(_user, message: event.message);
+      } on Failure catch (_) {
+        yield state;
+      }
+    }
+  }
+
+  Stream<ProfilePageState> mapEventToProfileEditing(ProfilePageEvent event) async* {
     if (event is ProfilePageEditStarted) {
       yield ProfilePageEditing(_user);
     }

--- a/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
+++ b/lib/screens/home/pages/profile/bloc/profile_page_bloc.dart
@@ -37,7 +37,7 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
         _user = await userRepository.getCurrentUser();
         yield ProfilePageSuccess(_user, message: event.message);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("ProfilePageBloc: Failure catched: $failure.message");
         yield ProfilePageFailure(message: failure.message);
       }
     }
@@ -50,7 +50,7 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
         _user = await userRepository.getCurrentUser();
         yield ProfilePageSuccess(_user, message: event.message);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("ProfilePageBloc: Failure catched: $failure.message");
         yield state;
       }
     }
@@ -80,7 +80,7 @@ class ProfilePageBloc extends Bloc<ProfilePageEvent, ProfilePageState> {
         CustomResponse response = await userRepository.updateUser(updatedUser);
         add(ProfilePageShowed(message: response.message));
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("ProfilePageBloc: Failure catched: $failure.message");
         add(ProfilePageShowed(message: failure.message));
       }
     }

--- a/lib/screens/home/pages/profile/bloc/profile_page_event.dart
+++ b/lib/screens/home/pages/profile/bloc/profile_page_event.dart
@@ -14,6 +14,12 @@ class ProfilePageShowed extends ProfilePageEvent {
   ProfilePageShowed({this.message});
 }
 
+class ProfilePageRefresh extends ProfilePageEvent {
+  final String message;
+
+  ProfilePageRefresh({this.message});
+}
+
 class ProfilePageEditStarted extends ProfilePageEvent {}
 
 class ProfilePageEditSubmitted extends ProfilePageEvent {

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -99,10 +99,6 @@ class _ProfilePageState extends State<ProfilePage> {
             if (_needsMentoring == null) _needsMentoring = state.user.needsMentoring;
           }
           if (state is ProfilePageShowed) {
-            ProfilePageBloc(userRepository: UserRepository.instance)
-              ..add(
-                ProfilePageRefresh(),
-              );
             _refreshCompleter?.complete();
             _refreshCompleter = Completer();
           }

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -101,7 +101,7 @@ class _ProfilePageState extends State<ProfilePage> {
           if (state is ProfilePageShowed) {
             ProfilePageBloc(userRepository: UserRepository.instance)
               ..add(
-                ProfilePageShowed(),
+                ProfilePageRefresh(),
               );
             _refreshCompleter?.complete();
             _refreshCompleter = Completer();

--- a/lib/screens/home/pages/profile/profile_page.dart
+++ b/lib/screens/home/pages/profile/profile_page.dart
@@ -26,14 +26,14 @@ class _ProfilePageState extends State<ProfilePage> {
   bool _needsMentoring;
   bool editing = false;
 
-  @override
-  void initState() {
-    context.bloc<ProfilePageBloc>()..add(ProfilePageShowed());
-    super.initState();
-  }
+  // @override
+  // void initState() {
+  //   super.initState();
+  // }
 
   @override
   Widget build(BuildContext context) {
+
     User user = User();
     return Scaffold(
       floatingActionButton:

--- a/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
+++ b/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
@@ -39,6 +39,19 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
         yield RelationPageFailure(message: failure.message);
       }
     }
+    if (event is RelationPageRefresh) {
+      yield RelationPageLoading();
+      try {
+        Relation relation = await relationRepository.getCurrentRelation();
+        List<Task> tasks;
+        if (relation != null) {
+          tasks = await taskRepository.getAllTasks(relation.id);
+        }
+        yield RelationPageSuccess(relation, tasks);
+      } on Failure catch (_) {
+        yield state;
+      }
+    }
 
     if (event is RelationPageCancelledRelation) {
       yield RelationPageLoading();
@@ -88,6 +101,4 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
       }
     }
   }
-
-  Stream<RelationPageState> mapEventToRelationShowed(RelationPageEvent event) async* {}
 }

--- a/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
+++ b/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
@@ -88,4 +88,6 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
       }
     }
   }
+
+  Stream<RelationPageState> mapEventToRelationShowed(RelationPageEvent event) async* {}
 }

--- a/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
+++ b/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
@@ -48,7 +48,8 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
           tasks = await taskRepository.getAllTasks(relation.id);
         }
         yield RelationPageSuccess(relation, tasks);
-      } on Failure catch (_) {
+      } on Failure catch (failure) {
+        Logger.root.severe(failure.message);
         yield state;
       }
     }

--- a/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
+++ b/lib/screens/home/pages/relation/bloc/relation_page_bloc.dart
@@ -49,7 +49,7 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
         }
         yield RelationPageSuccess(relation, tasks);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RelationPageBloc: Failure catched: $failure.message");
         yield state;
       }
     }
@@ -62,7 +62,7 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
             message: response
                 .message); // Failure, because relation doesn't exist anymore. It's kinda dirty but works
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RelationPageBloc: Failure catched: $failure.message");
         yield RelationPageFailure(message: failure.message);
       }
     }
@@ -74,7 +74,7 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
         var tasks = await taskRepository.getAllTasks(event.relation.id);
         yield RelationPageSuccess(event.relation, tasks, message: response.message);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RelationPageBloc: Failure catched: $failure.message");
         yield RelationPageFailure(message: failure.message);
       }
     }
@@ -86,7 +86,7 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
         var tasks = await taskRepository.getAllTasks(event.relation.id);
         yield RelationPageSuccess(event.relation, tasks, message: response.message);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RelationPageBloc: Failure catched: $failure.message");
         yield RelationPageFailure(message: failure.message);
       }
     }
@@ -97,7 +97,7 @@ class RelationPageBloc extends Bloc<RelationPageEvent, RelationPageState> {
         var tasks = await taskRepository.getAllTasks(event.relation.id);
         yield RelationPageSuccess(event.relation, tasks, message: response.message);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RelationPageBloc: Failure catched: $failure.message");
         yield RelationPageFailure(message: failure.message);
       }
     }

--- a/lib/screens/home/pages/relation/bloc/relation_page_event.dart
+++ b/lib/screens/home/pages/relation/bloc/relation_page_event.dart
@@ -11,6 +11,11 @@ class RelationPageShowed extends RelationPageEvent {
   List<Object> get props => null;
 }
 
+class RelationPageRefresh extends RelationPageEvent {
+  @override
+  List<Object> get props => null;
+}
+
 class RelationPageCancelledRelation extends RelationPageEvent {
   final int relationId;
 
@@ -39,7 +44,6 @@ class TaskCompleted extends RelationPageEvent {
   @override
   List<Object> get props => [relation, taskId];
 }
-
 
 class TaskDeleted extends RelationPageEvent {
   final Relation relation;

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -43,10 +43,6 @@ class _RelationPageState extends State<RelationPage> {
             context.showSnackBar(state.message);
           }
           if (state is RelationPageShowed) {
-            RelationPageBloc(
-              relationRepository: RelationRepository.instance,
-              taskRepository: TaskRepository.instance,
-            )..add(RelationPageRefresh());
             _refreshCompleter?.complete();
             _refreshCompleter = Completer();
           }

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -18,8 +18,6 @@ class RelationPage extends StatefulWidget {
 class _RelationPageState extends State<RelationPage> {
   @override
   Widget build(BuildContext context) {
-    BlocProvider.of<RelationPageBloc>(context).add(RelationPageShowed());
-
     return DefaultTabController(
       length: 2,
       child: Scaffold(

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -5,8 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mentorship_client/extensions/context.dart';
 import 'package:mentorship_client/extensions/datetime.dart';
 import 'package:mentorship_client/remote/models/task.dart';
-import 'package:mentorship_client/remote/repositories/relation_repository.dart';
-import 'package:mentorship_client/remote/repositories/task_repository.dart';
 import 'package:mentorship_client/remote/requests/task_request.dart';
 import 'package:mentorship_client/screens/home/pages/relation/bloc/bloc.dart';
 import 'package:mentorship_client/widgets/bold_text.dart';

--- a/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
+++ b/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
@@ -33,7 +33,7 @@ class RequestsPageBloc extends Bloc<RequestsPageEvent, RequestsPageState> {
         List<Relation> relations = await relationRepository.getAllRelationsAndRequests();
         yield RequestsPageSuccess(relations);
       } on Failure catch (failure) {
-        Logger.root.severe("RequestsPageBloc: ${failure.message}");
+        Logger.root.severe("RequestsPageBloc: Failure catched: $failure.message");
         yield RequestsPageFailure(message: failure.message);
       }
     }
@@ -46,7 +46,7 @@ class RequestsPageBloc extends Bloc<RequestsPageEvent, RequestsPageState> {
         List<Relation> relations = await relationRepository.getAllRelationsAndRequests();
         yield RequestsPageSuccess(relations);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("RequestsPageBloc: Failure catched: $failure.message");
         yield state;
       }
     }

--- a/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
+++ b/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
@@ -45,7 +45,8 @@ class RequestsPageBloc extends Bloc<RequestsPageEvent, RequestsPageState> {
       try {
         List<Relation> relations = await relationRepository.getAllRelationsAndRequests();
         yield RequestsPageSuccess(relations);
-      } on Failure catch (_) {
+      } on Failure catch (failure) {
+        Logger.root.severe(failure.message);
         yield state;
       }
     }

--- a/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
+++ b/lib/screens/home/pages/requests/bloc/requests_page_bloc.dart
@@ -20,6 +20,14 @@ class RequestsPageBloc extends Bloc<RequestsPageEvent, RequestsPageState> {
   @override
   Stream<RequestsPageState> mapEventToState(RequestsPageEvent event) async* {
     if (event is RequestsPageShowed) {
+      yield* _mapEventToRequestsShowed(event);
+    } else if (event is RequestsPageRefresh) {
+      yield* _mapEventToRequestsRefresh(event);
+    }
+  }
+
+  Stream<RequestsPageState> _mapEventToRequestsShowed(RequestsPageEvent event) async* {
+    if (event is RequestsPageShowed) {
       yield RequestsPageLoading();
       try {
         List<Relation> relations = await relationRepository.getAllRelationsAndRequests();
@@ -27,6 +35,18 @@ class RequestsPageBloc extends Bloc<RequestsPageEvent, RequestsPageState> {
       } on Failure catch (failure) {
         Logger.root.severe("RequestsPageBloc: ${failure.message}");
         yield RequestsPageFailure(message: failure.message);
+      }
+    }
+  }
+
+  Stream<RequestsPageState> _mapEventToRequestsRefresh(RequestsPageEvent event) async* {
+    if (event is RequestsPageRefresh) {
+      yield RequestsPageLoading();
+      try {
+        List<Relation> relations = await relationRepository.getAllRelationsAndRequests();
+        yield RequestsPageSuccess(relations);
+      } on Failure catch (_) {
+        yield state;
       }
     }
   }

--- a/lib/screens/home/pages/requests/bloc/requests_page_event.dart
+++ b/lib/screens/home/pages/requests/bloc/requests_page_event.dart
@@ -9,11 +9,7 @@ class RequestsPageShowed extends RequestsPageEvent {
   List<Object> get props => null;
 }
 
-//class RequestsPageRelationAccepted extends RequestsPageEvent {
-//  final int relationId;
-//
-//  RequestsPageRelationAccepted(this.relationId);
-//
-//  @override
-//  List<Object> get props => [relationId];
-//}
+class RequestsPageRefresh extends RequestsPageEvent {
+  @override
+  List<Object> get props => null;
+}

--- a/lib/screens/home/pages/requests/requests_page.dart
+++ b/lib/screens/home/pages/requests/requests_page.dart
@@ -15,8 +15,6 @@ class RequestsPage extends StatefulWidget {
 class _RequestsPageState extends State<RequestsPage> {
   @override
   Widget build(BuildContext context) {
-    BlocProvider.of<RequestsPageBloc>(context).add(RequestsPageShowed());
-
     return DefaultTabController(
       length: 3,
       child: Scaffold(

--- a/lib/screens/home/pages/requests/requests_page.dart
+++ b/lib/screens/home/pages/requests/requests_page.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mentorship_client/extensions/datetime.dart';
 import 'package:mentorship_client/remote/models/relation.dart';
+import 'package:mentorship_client/screens/home/pages/members/bloc/bloc.dart';
 import 'package:mentorship_client/screens/home/pages/requests/bloc/bloc.dart';
 import 'package:mentorship_client/screens/request_detail/request_detail.dart';
 import 'package:mentorship_client/widgets/bold_text.dart';
@@ -13,6 +16,14 @@ class RequestsPage extends StatefulWidget {
 }
 
 class _RequestsPageState extends State<RequestsPage> {
+  Completer<void> _refreshCompleter;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshCompleter = Completer<void>();
+  }
+
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -26,94 +37,116 @@ class _RequestsPageState extends State<RequestsPage> {
             Tab(text: "All".toUpperCase()),
           ],
         ),
-        body: BlocBuilder<RequestsPageBloc, RequestsPageState>(builder: (context, state) {
-          if (state is RequestsPageSuccess) {
-            state.relations.sort((rel1, rel2) => rel2.sentOn.compareTo(rel1.sentOn));
+        body: BlocConsumer<RequestsPageBloc, RequestsPageState>(
+          listener: (context, state) {
+            if (state is RequestsPageShowed) {
+              _refreshCompleter?.complete();
+              _refreshCompleter = Completer();
+            }
+          },
+          builder: (context, state) {
+            return BlocBuilder<RequestsPageBloc, RequestsPageState>(
+              builder: (context, state) {
+                if (state is RequestsPageSuccess) {
+                  state.relations.sort((rel1, rel2) => rel2.sentOn.compareTo(rel1.sentOn));
 
-            List<Relation> pendingRelations =
-                state.relations.where((rel) => rel.state == 1).toList();
-            List<Relation> pastRelations = state.relations.where((rel) => rel.state != 1).toList();
-            List<Relation> allRelations = state.relations;
+                  List<Relation> pendingRelations =
+                      state.relations.where((rel) => rel.state == 1).toList();
+                  List<Relation> pastRelations =
+                      state.relations.where((rel) => rel.state != 1).toList();
+                  List<Relation> allRelations = state.relations;
 
-            return TabBarView(
-              children: [
-                pendingRelations.length == 0
-                    ? NoRequestsInfo(message: "You don't have any pending mentorship requests.")
-                    : _buildRequestsTab(context, pendingRelations),
-                pastRelations.length == 0
-                    ? NoRequestsInfo(
-                        message: "You don't have any past mentorship requests.",
-                      )
-                    : _buildRequestsTab(context, pastRelations),
-                allRelations.length == 0
-                    ? NoRequestsInfo(message: "You don't have any mentorship requests.")
-                    : _buildRequestsTab(context, allRelations),
-              ],
+                  return TabBarView(
+                    children: [
+                      pendingRelations.length == 0
+                          ? NoRequestsInfo(
+                              message: "You don't have any pending mentorship requests.")
+                          : _buildRequestsTab(context, pendingRelations),
+                      pastRelations.length == 0
+                          ? NoRequestsInfo(
+                              message: "You don't have any past mentorship requests.",
+                            )
+                          : _buildRequestsTab(context, pastRelations),
+                      allRelations.length == 0
+                          ? NoRequestsInfo(message: "You don't have any mentorship requests.")
+                          : _buildRequestsTab(context, allRelations),
+                    ],
+                  );
+                }
+
+                if (state is RequestsPageFailure) {
+                  return Center(
+                    child: Text(state.message),
+                  );
+                }
+
+                return LoadingIndicator();
+              },
             );
-          }
-
-          if (state is RequestsPageFailure) {
-            return Center(
-              child: Text(state.message),
-            );
-          }
-
-          return LoadingIndicator();
-        }),
+          },
+        ),
       ),
     );
   }
 
   Widget _buildRequestsTab(BuildContext context, List<Relation> relations) {
-    return ListView.builder(
-      itemCount: relations.length,
-      itemBuilder: (context, index) {
-        Relation relation = relations[index];
-
-        DateTime startDate = DateTimeX.fromTimestamp(relation.sentOn);
-        DateTime endDate = DateTimeX.fromTimestamp(relation.endsOn);
-
-        return InkWell(
-          onTap: () => Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => RequestDetailScreen(relation: relation),
-            ),
-          ),
-          child: ListTile(
-            title: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          BoldText("Mentor: ", relation.mentor.name),
-                          BoldText("Mentee: ", relation.mentee.name),
-                          BoldText("End date: ", endDate.toDateString()),
-                        ],
-                      ),
-                    ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Text("Sent on ${startDate.toDateString()}"),
-                        SizedBox(height: 4),
-                        if (relation.sentByMe) Text("Sent by me") else Text("To me")
-                      ],
-                    )
-                  ],
-                ),
-                BoldText("Notes: ", relation.notes),
-                Divider(),
-              ],
-            ),
-          ),
+    return RefreshIndicator(
+      onRefresh: () {
+        BlocProvider.of<RequestsPageBloc>(context).add(
+          RequestsPageRefresh(),
         );
+        return _refreshCompleter.future;
       },
+      child: ListView.builder(
+        itemCount: relations.length,
+        itemBuilder: (context, index) {
+          Relation relation = relations[index];
+
+          DateTime startDate = DateTimeX.fromTimestamp(relation.sentOn);
+          DateTime endDate = DateTimeX.fromTimestamp(relation.endsOn);
+
+          return InkWell(
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => RequestDetailScreen(relation: relation),
+              ),
+            ),
+            child: ListTile(
+              title: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            BoldText("Mentor: ", relation.mentor.name),
+                            BoldText("Mentee: ", relation.mentee.name),
+                            BoldText("End date: ", endDate.toDateString()),
+                          ],
+                        ),
+                      ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          Text("Sent on ${startDate.toDateString()}"),
+                          SizedBox(height: 4),
+                          if (relation.sentByMe) Text("Sent by me") else Text("To me")
+                        ],
+                      )
+                    ],
+                  ),
+                  BoldText("Notes: ", relation.notes),
+                  Divider(),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
+++ b/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:mentorship_client/failure.dart';
 import 'package:mentorship_client/remote/models/home_stats.dart';
 import 'package:mentorship_client/remote/repositories/user_repository.dart';
+import 'package:mentorship_client/screens/home/pages/stats/stats_page.dart';
 
 import './bloc.dart';
 
@@ -19,6 +20,14 @@ class StatsPageBloc extends Bloc<StatsPageEvent, StatsPageState> {
   @override
   Stream<StatsPageState> mapEventToState(StatsPageEvent event) async* {
     if (event is StatsPageShowed) {
+      yield* _mapStatsRequested(event);
+    } else if (event is StatsPageRefresh) {
+      yield* _mapStatsRefreshRequested(event);
+    }
+  }
+
+  Stream<StatsPageState> _mapStatsRequested(StatsPageEvent event) async* {
+    if (event is StatsPageShowed) {
       yield StatsPageLoading();
       try {
         final HomeStats homeStats = await userRepository.getHomeStats();
@@ -26,6 +35,18 @@ class StatsPageBloc extends Bloc<StatsPageEvent, StatsPageState> {
       } on Failure catch (failure) {
         Logger.root.severe(failure.message);
         yield StatsPageFailure(failure.message);
+      }
+    }
+  }
+
+  Stream<StatsPageState> _mapStatsRefreshRequested(StatsPageEvent event) async* {
+    if (event is StatsPageRefresh) {
+      yield StatsPageLoading();
+      try {
+        final HomeStats homeStats = await userRepository.getHomeStats();
+        yield StatsPageSuccess(homeStats);
+      } on Failure catch (_) {
+        yield state;
       }
     }
   }

--- a/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
+++ b/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
@@ -5,7 +5,6 @@ import 'package:logging/logging.dart';
 import 'package:mentorship_client/failure.dart';
 import 'package:mentorship_client/remote/models/home_stats.dart';
 import 'package:mentorship_client/remote/repositories/user_repository.dart';
-import 'package:mentorship_client/screens/home/pages/stats/stats_page.dart';
 
 import './bloc.dart';
 
@@ -33,7 +32,7 @@ class StatsPageBloc extends Bloc<StatsPageEvent, StatsPageState> {
         final HomeStats homeStats = await userRepository.getHomeStats();
         yield StatsPageSuccess(homeStats);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("StatsPageBloc: Failure catched: $failure.message");
         yield StatsPageFailure(failure.message);
       }
     }
@@ -46,7 +45,7 @@ class StatsPageBloc extends Bloc<StatsPageEvent, StatsPageState> {
         final HomeStats homeStats = await userRepository.getHomeStats();
         yield StatsPageSuccess(homeStats);
       } on Failure catch (failure) {
-        Logger.root.severe(failure.message);
+        Logger.root.severe("StatsPageBloc: Failure catched: $failure.message");
         yield state;
       }
     }

--- a/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
+++ b/lib/screens/home/pages/stats/bloc/stats_page_bloc.dart
@@ -45,7 +45,8 @@ class StatsPageBloc extends Bloc<StatsPageEvent, StatsPageState> {
       try {
         final HomeStats homeStats = await userRepository.getHomeStats();
         yield StatsPageSuccess(homeStats);
-      } on Failure catch (_) {
+      } on Failure catch (failure) {
+        Logger.root.severe(failure.message);
         yield state;
       }
     }

--- a/lib/screens/home/pages/stats/bloc/stats_page_event.dart
+++ b/lib/screens/home/pages/stats/bloc/stats_page_event.dart
@@ -8,3 +8,5 @@ abstract class StatsPageEvent extends Equatable {
 }
 
 class StatsPageShowed extends StatsPageEvent {}
+
+class StatsPageRefresh extends StatsPageEvent {}

--- a/lib/screens/home/pages/stats/stats_page.dart
+++ b/lib/screens/home/pages/stats/stats_page.dart
@@ -4,6 +4,7 @@ import 'package:mentorship_client/remote/models/task.dart';
 import 'package:mentorship_client/remote/repositories/user_repository.dart';
 import 'package:mentorship_client/screens/home/pages/stats/bloc/bloc.dart';
 import 'package:mentorship_client/widgets/loading_indicator.dart';
+import 'dart:async';
 
 /// First page from the left on the HomeScreen. Displays welcome message to the user
 /// and provides some information on latest achievements.
@@ -15,68 +16,98 @@ class StatsPage extends StatefulWidget {
 }
 
 class _StatsPageState extends State<StatsPage> {
+  Completer<void> _refreshCompleter;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshCompleter = Completer<void>();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<StatsPageBloc, StatsPageState>(builder: (context, state) {
-      if (state is StatsPageSuccess) {
-        return Padding(
-          padding: EdgeInsets.symmetric(horizontal: 8),
-          child: ListView(
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                child: Text(
-                  "Welcome, ${state.homeStats.name}!",
-                  textScaleFactor: 2,
-                  style: TextStyle(fontWeight: FontWeight.bold),
+    return BlocConsumer<StatsPageBloc, StatsPageState>(
+      listener: (context, state) {
+        if (state is StatsPageShowed) {
+          StatsPageBloc(userRepository: UserRepository.instance)
+            ..add(
+              StatsPageRefresh(),
+            );
+          _refreshCompleter?.complete();
+          _refreshCompleter = Completer();
+        }
+      },
+      builder: (context, state) {
+        return BlocBuilder<StatsPageBloc, StatsPageState>(builder: (context, state) {
+          if (state is StatsPageSuccess) {
+            return RefreshIndicator(
+              onRefresh: () {
+                BlocProvider.of<StatsPageBloc>(context).add(
+                  StatsPageRefresh(),
+                );
+                return _refreshCompleter.future;
+              },
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8),
+                child: ListView(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      child: Text(
+                        "Welcome, ${state.homeStats.name}!",
+                        textScaleFactor: 2,
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    Column(
+                      children: [
+                        _buildRow("Pending Requests", state.homeStats.pendingRequests),
+                        _buildRow("Accepted Requests", state.homeStats.acceptedRequests),
+                        _buildRow("Rejected Requests", state.homeStats.rejectedRequests),
+                        _buildRow("Completed Relations", state.homeStats.completedRelations),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(0, 24, 0, 12),
+                          child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                "Recent Achievements",
+                                style: Theme.of(context).textTheme.headline6,
+                              )),
+                        ),
+                        for (Task achievement in state.homeStats.achievements)
+                          Column(
+                            children: <Widget>[
+                              Row(
+                                children: [
+                                  Checkbox(
+                                    value: true,
+                                    onChanged: (status) => null,
+                                    hoverColor: Theme.of(context).accentColor,
+                                  ),
+                                  Text(achievement.description),
+                                ],
+                              ),
+                              Divider(),
+                            ],
+                          ),
+                      ],
+                    )
+                  ],
                 ),
               ),
-              Column(
-                children: [
-                  _buildRow("Pending Requests", state.homeStats.pendingRequests),
-                  _buildRow("Accepted Requests", state.homeStats.acceptedRequests),
-                  _buildRow("Rejected Requests", state.homeStats.rejectedRequests),
-                  _buildRow("Completed Relations", state.homeStats.completedRelations),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 24, 0, 12),
-                    child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          "Recent Achievements",
-                          style: Theme.of(context).textTheme.headline6,
-                        )),
-                  ),
-                  for (Task achievement in state.homeStats.achievements)
-                    Column(
-                      children: <Widget>[
-                        Row(
-                          children: [
-                            Checkbox(
-                              value: true,
-                              onChanged: (status) => null,
-                              hoverColor: Theme.of(context).accentColor,
-                            ),
-                            Text(achievement.description),
-                          ],
-                        ),
-                        Divider(),
-                      ],
-                    ),
-                ],
-              )
-            ],
-          ),
-        );
-      }
-      if (state is StatsPageFailure) {
-        return Text(state.message);
-      }
+            );
+          }
+          if (state is StatsPageFailure) {
+            return Text(state.message);
+          }
 
-      if (state is StatsPageLoading) {
-        return LoadingIndicator();
-      } else
-        return Text("an error occurred");
-    });
+          if (state is StatsPageLoading) {
+            return LoadingIndicator();
+          } else
+            return Text("an error occurred");
+        });
+      },
+    );
   }
 
   Widget _buildRow(String text, int count) {

--- a/lib/screens/home/pages/stats/stats_page.dart
+++ b/lib/screens/home/pages/stats/stats_page.dart
@@ -29,10 +29,6 @@ class _StatsPageState extends State<StatsPage> {
     return BlocConsumer<StatsPageBloc, StatsPageState>(
       listener: (context, state) {
         if (state is StatsPageShowed) {
-          StatsPageBloc(userRepository: UserRepository.instance)
-            ..add(
-              StatsPageRefresh(),
-            );
           _refreshCompleter?.complete();
           _refreshCompleter = Completer();
         }

--- a/lib/screens/home/pages/stats/stats_page.dart
+++ b/lib/screens/home/pages/stats/stats_page.dart
@@ -7,6 +7,8 @@ import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 /// First page from the left on the HomeScreen. Displays welcome message to the user
 /// and provides some information on latest achievements.
+///
+
 class StatsPage extends StatefulWidget {
   @override
   _StatsPageState createState() => _StatsPageState();
@@ -15,70 +17,66 @@ class StatsPage extends StatefulWidget {
 class _StatsPageState extends State<StatsPage> {
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<StatsPageBloc>(
-      create: (context) =>
-          StatsPageBloc(userRepository: UserRepository.instance)..add(StatsPageShowed()),
-      child: BlocBuilder<StatsPageBloc, StatsPageState>(builder: (context, state) {
-        if (state is StatsPageSuccess) {
-          return Padding(
-            padding: EdgeInsets.symmetric(horizontal: 8),
-            child: ListView(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 24),
-                  child: Text(
-                    "Welcome, ${state.homeStats.name}!",
-                    textScaleFactor: 2,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
+    return BlocBuilder<StatsPageBloc, StatsPageState>(builder: (context, state) {
+      if (state is StatsPageSuccess) {
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8),
+          child: ListView(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                child: Text(
+                  "Welcome, ${state.homeStats.name}!",
+                  textScaleFactor: 2,
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
-                Column(
-                  children: [
-                    _buildRow("Pending Requests", state.homeStats.pendingRequests),
-                    _buildRow("Accepted Requests", state.homeStats.acceptedRequests),
-                    _buildRow("Rejected Requests", state.homeStats.rejectedRequests),
-                    _buildRow("Completed Relations", state.homeStats.completedRelations),
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 24, 0, 12),
-                      child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: Text(
-                            "Recent Achievements",
-                            style: Theme.of(context).textTheme.headline6,
-                          )),
+              ),
+              Column(
+                children: [
+                  _buildRow("Pending Requests", state.homeStats.pendingRequests),
+                  _buildRow("Accepted Requests", state.homeStats.acceptedRequests),
+                  _buildRow("Rejected Requests", state.homeStats.rejectedRequests),
+                  _buildRow("Completed Relations", state.homeStats.completedRelations),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 24, 0, 12),
+                    child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          "Recent Achievements",
+                          style: Theme.of(context).textTheme.headline6,
+                        )),
+                  ),
+                  for (Task achievement in state.homeStats.achievements)
+                    Column(
+                      children: <Widget>[
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: true,
+                              onChanged: (status) => null,
+                              hoverColor: Theme.of(context).accentColor,
+                            ),
+                            Text(achievement.description),
+                          ],
+                        ),
+                        Divider(),
+                      ],
                     ),
-                    for (Task achievement in state.homeStats.achievements)
-                      Column(
-                        children: <Widget>[
-                          Row(
-                            children: [
-                              Checkbox(
-                                value: true,
-                                onChanged: (status) => null,
-                                hoverColor: Theme.of(context).accentColor,
-                              ),
-                              Text(achievement.description),
-                            ],
-                          ),
-                          Divider(),
-                        ],
-                      ),
-                  ],
-                )
-              ],
-            ),
-          );
-        }
-        if (state is StatsPageFailure) {
-          return Text(state.message);
-        }
+                ],
+              )
+            ],
+          ),
+        );
+      }
+      if (state is StatsPageFailure) {
+        return Text(state.message);
+      }
 
-        if (state is StatsPageLoading) {
-          return LoadingIndicator();
-        } else
-          return Text("an error occurred");
-      }),
-    );
+      if (state is StatsPageLoading) {
+        return LoadingIndicator();
+      } else
+        return Text("an error occurred");
+    });
   }
 
   Widget _buildRow(String text, int count) {


### PR DESCRIPTION
### Description

Fixes #109 

Right now every time we switch pages, the app makes a network call and gets the data, this makes the app feel slow. With this fix the app persists the data on the page and is updated when user pulls down to refresh. This is similar to the store data locally PR on mentorship-android [here](https://github.com/anitab-org/mentorship-android/pull/718#) , but more developed because 

1. Does not store it in local storage,(not exactly), the data is persisted in the state itself by blocs and app does not make new network calls untill pulled down to refreshed or updated from something in the page itself like updating the profile or creating/deleting tasks.

2. Its for all the pages not only profile page data. So if someone makes a change on the web version (in development) or ios, just one pull down to refresh and the changes are updated on screen. 



### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface


**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Physical device.
PS: videos wont show how much improvment this actually brings because it is capped at 7 Fps. i would suggest to test this yourself manually on your device/emulator

|Before|After|
|---|---|
| ![before](https://user-images.githubusercontent.com/52817235/85524283-aa929600-b625-11ea-883a-1b576bb3ce49.gif)|![after](https://user-images.githubusercontent.com/52817235/85525308-98652780-b626-11ea-9d6c-d4f237299931.gif)  |


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
