### PR TITLE
feat: add delete icon to delete a task instead of just clicking on the task tile

### DIFF
--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -182,7 +182,7 @@ class _RelationPageState extends State<RelationPage> {
                             FlatButton(
                               child: Text("Delete"),
                               onPressed: () {
-                                // bloc.add(TaskDeleted(state.relation, task.id));
+                                bloc.add(TaskDeleted(state.relation, task.id));
                                 Navigator.of(context).pop();
                                 showProgressIndicator(context);
                               },

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -162,7 +162,10 @@ class _RelationPageState extends State<RelationPage> {
                     ],
                   ),
                   IconButton(
-                    icon: Icon(Icons.delete, color: Colors.grey[700],),
+                    icon: Icon(
+                      Icons.delete,
+                      color: Colors.grey[700],
+                    ),
                     onPressed: () {
                       showDialog(
                         context: context,
@@ -171,13 +174,19 @@ class _RelationPageState extends State<RelationPage> {
                           content: Text("Are you sure you want to delete the task?"),
                           actions: [
                             FlatButton(
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                              child: Text("Cancel"),
+                            ),
+                            FlatButton(
                               child: Text("Delete"),
                               onPressed: () {
-                                bloc.add(TaskDeleted(state.relation, task.id));
+                                // bloc.add(TaskDeleted(state.relation, task.id));
                                 Navigator.of(context).pop();
                                 showProgressIndicator(context);
                               },
-                            )
+                            ),
                           ],
                         ),
                       );

--- a/lib/screens/home/pages/relation/relation_page.dart
+++ b/lib/screens/home/pages/relation/relation_page.dart
@@ -140,43 +140,50 @@ class _RelationPageState extends State<RelationPage> {
               //ignore: close_sinks
               final bloc = BlocProvider.of<RelationPageBloc>(context);
 
-              return InkWell(
-                onTap: () {
-                  showDialog(
-                    context: context,
-                    builder: (context) => AlertDialog(
-                      title: Text("Delete task"),
-                      content: Text("Are you sure you want to delete the task?"),
-                      actions: [
-                        FlatButton(
-                          child: Text("Delete"),
-                          onPressed: () {
-                            bloc.add(TaskDeleted(state.relation, task.id));
-                            Navigator.of(context).pop();
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          if (!task.isDone) {
+                            bloc.add(TaskCompleted(state.relation, task.id));
                             showProgressIndicator(context);
-                          },
-                        )
-                      ],
-                    ),
-                  );
-                },
-                child: Row(
-                  children: [
-                    GestureDetector(
-                      onTap: () {
-                        if (!task.isDone) {
-                          bloc.add(TaskCompleted(state.relation, task.id));
-                          showProgressIndicator(context);
-                        } else
-                          context.toast("Task already achieved.");
-                      },
-                      child: Checkbox(
-                        value: task.isDone,
+                          } else
+                            context.toast("Task already achieved.");
+                        },
+                        child: Checkbox(
+                          value: task.isDone,
+                        ),
                       ),
-                    ),
-                    Text(task.description),
-                  ],
-                ),
+                      Text(task.description),
+                    ],
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.delete, color: Colors.grey[700],),
+                    onPressed: () {
+                      showDialog(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: Text("Delete task"),
+                          content: Text("Are you sure you want to delete the task?"),
+                          actions: [
+                            FlatButton(
+                              child: Text("Delete"),
+                              onPressed: () {
+                                bloc.add(TaskDeleted(state.relation, task.id));
+                                Navigator.of(context).pop();
+                                showProgressIndicator(context);
+                              },
+                            )
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ],
               );
             },
           );


### PR DESCRIPTION
### Description
Add a delete button on the task tile in the relation page

Fixes #100 

### Flutter Channel:
- [ ] I have used the Flutter Beta channel on my local machine 

### Type of Change:

- Code

**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
On a physical device
Steps:
- Go to the Tasks tab in the relations page by clicking on the relation page icon in the bottom navigation bar
- Here's a demo of the same
![20200624_145010](https://user-images.githubusercontent.com/58745044/85528994-3c040700-b62a-11ea-9389-29269845f9e7.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings