### PR TITLE
Fix members page reload

### DIFF
--- a/lib/screens/home/pages/members/bloc/members_page_bloc.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_bloc.dart
@@ -55,7 +55,7 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
   Stream<MembersPageState> _mapEventToMembersRefresh(MembersPageEvent event) async* {
     final currentState = state;
 
-    if (event is MembersPageRefresh && !_hasReachedMax(currentState)) {
+    if (event is MembersPageRefresh) {
       try {
         yield MembersPageLoading();
         final List<User> users = await userRepository.getVerifiedUsers(pageNumber);


### PR DESCRIPTION
 ## Description
User should be able to refresh the page even if he/she has reached the end

Fixes #115 


### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Physical device


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
