### PR TITLE
Fix for #134 delete account button removed

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -40,13 +40,6 @@ class SettingsScreen extends StatelessWidget {
               title: Text("Change password"),
               onTap: () => _showChangePasswordDialog(context),
             ),
-            ListTile(
-              leading: Icon(Icons.delete_outline),
-              title: Text(
-                "Delete account",
-                style: TextStyle(color: Colors.red),
-              ),
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
### Description
The delete account button is removed from UI.

Fixes #134 

### Flutter Channel:
- [X] I have used the Flutter Beta channel on my local machine 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Before:
<img src ="https://user-images.githubusercontent.com/34762451/90911169-30e51180-e3f6-11ea-9d8d-13c8b30baac6.jpg" width="200">
After
<img src ="https://user-images.githubusercontent.com/34762451/90911204-3e9a9700-e3f6-11ea-814a-7ceb738b59cf.jpg" width="200">

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings