### PR TITLE
fix: Removed network call to backend server when transitioning from "Member Profile" to "Send Request" screen.

### DIFF
--- a/lib/remote/repositories/user_repository.dart
+++ b/lib/remote/repositories/user_repository.dart
@@ -18,7 +18,8 @@ class UserRepository {
 
   /// Returns home statistics for the current user
   Future<HomeStats> getHomeStats() async {
-    final body = await ApiManager.callSafely(() => ApiManager.instance.userService.getHomeStats());
+    final body = await ApiManager.callSafely(
+        () => ApiManager.instance.userService.getHomeStats());
     return HomeStats.fromJson(body);
   }
 
@@ -37,21 +38,22 @@ class UserRepository {
 
   /// Returns current user profile
   Future<User> getCurrentUser() async {
-    final body =
-        await ApiManager.callSafely(() => ApiManager.instance.userService.getCurrentUser());
+    final body = await ApiManager.callSafely(
+        () => ApiManager.instance.userService.getCurrentUser());
     return User.fromJson(body);
   }
 
   /// Returns user profile with the specified id
   Future<User> getUser(int userId) async {
-    final body = await ApiManager.callSafely(() => ApiManager.instance.userService.getUser(userId));
+    final body = await ApiManager.callSafely(
+        () => ApiManager.instance.userService.getUser(userId));
     return User.fromJson(body);
   }
 
   /// Updates current user's profile
   Future<CustomResponse> updateUser(User user) async {
-    final body =
-        await ApiManager.callSafely(() => ApiManager.instance.userService.updateUser(user));
+    final body = await ApiManager.callSafely(
+        () => ApiManager.instance.userService.updateUser(user));
     return CustomResponse.fromJson(body);
   }
 

--- a/lib/screens/home/pages/members/bloc/members_page_bloc.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_bloc.dart
@@ -46,13 +46,12 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
         if (currentState is MembersPageSuccess) {
           final users = await userRepository
               .getVerifiedUsers((currentState.users.length ~/ 10) + 1);
-          final User currentUser = await userRepository.getCurrentUser();
           yield users.isEmpty
               ? currentState.copyWith(hasReachedMax: true)
               : MembersPageSuccess(
                   users: currentState.users + users,
                   hasReachedMax: false,
-                  currentUser: currentUser,
+                  currentUser: currentState.currentUser,
                 );
         }
       } on Failure catch (failure) {
@@ -72,7 +71,9 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
         yield MembersPageLoading();
         final List<User> users =
             await userRepository.getVerifiedUsers(pageNumber);
-        final User currentUser = await userRepository.getCurrentUser();
+        final User currentUser = (currentState is MembersPageSuccess)
+            ? currentState.currentUser
+            : await userRepository.getCurrentUser();
         yield MembersPageSuccess(
           users: users,
           hasReachedMax: false,

--- a/lib/screens/home/pages/members/bloc/members_page_bloc.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_bloc.dart
@@ -12,8 +12,7 @@ import './bloc.dart';
 class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
   final UserRepository userRepository;
   int pageNumber = 1;
-  MembersPageBloc({@required this.userRepository})
-      : assert(userRepository != null);
+  MembersPageBloc({@required this.userRepository}) : assert(userRepository != null);
   @override
   MembersPageState get initialState => MembersPageInitial();
 
@@ -26,16 +25,14 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
     }
   }
 
-  Stream<MembersPageState> _mapEventToMembersShowed(
-      MembersPageEvent event) async* {
+  Stream<MembersPageState> _mapEventToMembersShowed(MembersPageEvent event) async* {
     final currentState = state;
 
     if (event is MembersPageShowed && !_hasReachedMax(currentState)) {
       try {
         if (currentState is MembersPageInitial) {
           yield MembersPageLoading();
-          final List<User> users =
-              await userRepository.getVerifiedUsers(pageNumber);
+          final List<User> users = await userRepository.getVerifiedUsers(pageNumber);
           final User currentUser = await userRepository.getCurrentUser();
           yield MembersPageSuccess(
             users: users,
@@ -44,8 +41,8 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
           );
         }
         if (currentState is MembersPageSuccess) {
-          final users = await userRepository
-              .getVerifiedUsers((currentState.users.length ~/ 10) + 1);
+          final users =
+              await userRepository.getVerifiedUsers((currentState.users.length ~/ 10) + 1);
           yield users.isEmpty
               ? currentState.copyWith(hasReachedMax: true)
               : MembersPageSuccess(
@@ -55,38 +52,31 @@ class MembersPageBloc extends Bloc<MembersPageEvent, MembersPageState> {
                 );
         }
       } on Failure catch (failure) {
-        Logger.root
-            .severe("MembersPageBloc: Failure catched: $failure.message");
+        Logger.root.severe("MembersPageBloc: Failure catched: $failure.message");
         yield MembersPageFailure(failure.message);
       }
     }
   }
 
-  Stream<MembersPageState> _mapEventToMembersRefresh(
-      MembersPageEvent event) async* {
+  Stream<MembersPageState> _mapEventToMembersRefresh(MembersPageEvent event) async* {
     final currentState = state;
 
     if (event is MembersPageRefresh) {
       try {
         yield MembersPageLoading();
-        final List<User> users =
-            await userRepository.getVerifiedUsers(pageNumber);
-        final User currentUser = (currentState is MembersPageSuccess)
-            ? currentState.currentUser
-            : await userRepository.getCurrentUser();
+        final List<User> users = await userRepository.getVerifiedUsers(pageNumber);
+        final User currentUser = (currentState as MembersPageSuccess).currentUser;
         yield MembersPageSuccess(
           users: users,
           hasReachedMax: false,
           currentUser: currentUser,
         );
       } on Failure catch (failure) {
-        Logger.root
-            .severe("MembersPageBloc: Failure catched: $failure.message");
+        Logger.root.severe("MembersPageBloc: Failure catched: $failure.message");
         yield state;
       }
     }
   }
 }
 
-bool _hasReachedMax(MembersPageState state) =>
-    state is MembersPageSuccess && state.hasReachedMax;
+bool _hasReachedMax(MembersPageState state) => state is MembersPageSuccess && state.hasReachedMax;

--- a/lib/screens/home/pages/members/bloc/members_page_state.dart
+++ b/lib/screens/home/pages/members/bloc/members_page_state.dart
@@ -14,11 +14,13 @@ class MembersPageLoading extends MembersPageState {}
 
 class MembersPageSuccess extends MembersPageState {
   final List<User> users;
+  final User currentUser;
   final bool hasReachedMax;
 
   MembersPageSuccess({
     this.users,
     this.hasReachedMax,
+    this.currentUser,
   });
 
   // We implemented copyWith so that we can copy an instance of MembersPageSuccess

--- a/lib/screens/home/pages/members/members_page.dart
+++ b/lib/screens/home/pages/members/members_page.dart
@@ -30,7 +30,8 @@ class _MembersPageState extends State<MembersPage> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocConsumer<MembersPageBloc, MembersPageState>(listener: (context, state) {
+    return BlocConsumer<MembersPageBloc, MembersPageState>(
+        listener: (context, state) {
       if (state is MembersPageShowed) {
         _refreshCompleter?.complete();
         _refreshCompleter = Completer();
@@ -75,11 +76,14 @@ class _MembersPageState extends State<MembersPage> {
                     return _reachedEnd
                         ? BottomLoader()
                         : InkWell(
-                            onTap: () => _openMemberProfileScreen(context, user),
+                            onTap: () =>
+                                _openMemberProfileScreen(context, user),
                             child: MemberListTile(user: user),
                           );
                   },
-                  itemCount: state.hasReachedMax ? (state.users.length) : (state.users.length + 1),
+                  itemCount: state.hasReachedMax
+                      ? (state.users.length)
+                      : (state.users.length + 1),
                   controller: _scrollController,
                 ),
               );
@@ -96,7 +100,10 @@ class _MembersPageState extends State<MembersPage> {
   void _openMemberProfileScreen(BuildContext context, User user) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => MemberProfileScreen(user: user),
+        builder: (context) => MemberProfileScreen(
+          user: user,
+          membersPageBloc: _membersPageBloc,
+        ),
       ),
     );
   }

--- a/lib/screens/member_profile/member_profile.dart
+++ b/lib/screens/member_profile/member_profile.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:mentorship_client/remote/models/user.dart';
-import 'package:mentorship_client/remote/repositories/user_repository.dart';
+import 'package:mentorship_client/screens/home/pages/members/bloc/bloc.dart';
 import 'package:mentorship_client/screens/member_profile/user_data_list.dart';
 import 'package:mentorship_client/screens/send_request/send_request_screen.dart';
 import 'package:mentorship_client/widgets/loading_indicator.dart';
 
 class MemberProfileScreen extends StatelessWidget {
   final User user;
+  final MembersPageBloc membersPageBloc;
 
-  const MemberProfileScreen({Key key, @required this.user})
-      : assert(user != null),
+  const MemberProfileScreen({
+    Key key,
+    @required this.user,
+    @required this.membersPageBloc,
+  })  : assert(user != null),
         super(key: key);
 
   @override
@@ -55,7 +59,9 @@ class MemberProfileScreen extends StatelessWidget {
                   ),
                   onPressed: () async {
                     showProgressIndicator(context);
-                    var currentUser = await UserRepository.instance.getCurrentUser();
+                    final User currentUser =
+                        (membersPageBloc.state as MembersPageSuccess)
+                            .currentUser;
                     Navigator.of(context).pop();
                     Navigator.of(context).push(
                       PageRouteBuilder(
@@ -69,7 +75,7 @@ class MemberProfileScreen extends StatelessWidget {
                       ),
                     );
                   }),
-            )
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Removed network call to backend server when transitioning from "Member Profile" to "Send Request" screen.

### Description
There was a redundant network call being made while transitioning from Member Profile Page to Send Request Page to get the current user details. The motivation was to remove that call to save device resources and provide a more seamless service to the user.

I changed the **members_page_state.dart** to include currentUser of type _User_ in _MembersPageSuccess_ state. This will have all the details of the current user.

I changed **members_page_bloc.dart** to make all the network calls to get current user details and pass that to _MembersPageSuccess_ object instance whenever it is created.

I changed **members_page.dart** to pass an instance of _MembersPageBloc_ to _MemberProfileScreen_.

I changed the **member_profile.dart** to accept the instance of _MemberPageBloc_ passed to it and use to to get current user details.


Fixes #121 

### Flutter Channel:
- [x] I have used the Flutter Beta channel on my local machine 

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
I have tested the code manually on my emulator and device. To reproduce, just go from Member Profile to Send Requesnt Page.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any dependent changes have been published in downstream modules