### PR TITLE
fix: github action

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
     
     # Setup Java environment in order to build the Android app.
-    - uses: actions/checkout@v2.3.1
-    - uses: actions/setup-java@v1.4.0
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-java@v1.4.3
       with:
         java-version: '12.x'
     
     # Setup the flutter environment.
-    - uses: subosito/flutter-action@v1.3.2
+    - uses: subosito/flutter-action@v1.4.0
       with:
         channel: 'beta'
     


### PR DESCRIPTION
### Description
Github deprecated some of  its commands, specifically the setenv and addPath. This PR updates the deps to fix this


### How Has This Been Tested?
Tested [here](https://github.com/Techno-Disaster/mentorship-flutter/actions/runs/413638666)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
